### PR TITLE
Handle CSV datasets & better handle updates to existing MCF

### DIFF
--- a/src/geometamaker/geometamaker.py
+++ b/src/geometamaker/geometamaker.py
@@ -278,8 +278,6 @@ class MetadataControl(object):
             for k, v in kwargs.items():
                 self.mcf['contact'][section][k] = v
 
-        # TODO: validate just the contact section instead?
-        # Not obvious how to do that using the complete schema.
         self.validate()
 
     def get_contact(self, section='default'):
@@ -446,20 +444,10 @@ class MetadataControl(object):
             attribute['abstract'] = abstract
         if units is not None:
             attribute['units'] = units
-        # TODO: I don't like using `type` as the argname,
-        # but that is the name of the MCF property, and making
-        # the setter's argnames match makes it convenient to do things
-        # like mc_a.set_band_description(1, **mc_b.get_band_description(1))
         if type is not None:
             attribute['type'] = type
 
         self.mcf['content_info']['attributes'][idx] = attribute
-        # TODO: cannot validate entire MCF here because this setter
-        # is called as part of the init process before other required MCF
-        # properties are set. Solutions could be to make create_band_description()
-        # and create_field_description() methods instead of calling these setters.
-        # Or figure out how to validate just one section of the MCF.
-        # self.validate()
 
     def get_band_description(self, band_number):
         """Get the attribute metadata for a band.
@@ -505,8 +493,6 @@ class MetadataControl(object):
             attribute['type'] = type
 
         self.mcf['content_info']['attributes'][idx] = attribute
-        # TODO: see comment in set_band_description
-        # self.validate()
 
     def get_field_description(self, name):
         """Get the attribute metadata for a field.

--- a/src/geometamaker/geometamaker.py
+++ b/src/geometamaker/geometamaker.py
@@ -510,8 +510,8 @@ class MetadataControl(object):
         with open(target_path, 'w') as file:
             file.write(yaml.dump(self.mcf, Dumper=_NoAliasDumper))
 
-    def write(self, schema='iso19139'):
-        """Write MCF and XML to disk.
+    def write(self):
+        """Write MCF and ISO-19139 XML to disk.
 
         This creates sidecar files with '.yml' and '.xml' extensions
         appended to the full filename of the data source. For example,
@@ -530,7 +530,7 @@ class MetadataControl(object):
         self.mcf['metadata']['datestamp'] = datetime.utcnow().strftime(
                 '%Y-%m-%d')
         self._write_mcf(self.mcf_path)
-        schema_obj = load_schema(schema)
+        schema_obj = load_schema('iso19139')
         xml_string = schema_obj.write(self.mcf)
         with open(f'{self.datasource}.xml', 'w') as xmlfile:
             xmlfile.write(xml_string)

--- a/src/geometamaker/geometamaker.py
+++ b/src/geometamaker/geometamaker.py
@@ -348,16 +348,17 @@ class MetadataControl(object):
     def set_license(self, name=None, url=None):
         """Add a license for the dataset.
 
+        Either or both name and url are required if there is a license.
+        Call with no arguments to remove access constraints and license
+        info.
+
         Args:
-            license (str): name of the license of the source dataset
+            name (str): name of the license of the source dataset
+            url (str): url for the license
 
         """
-        # One may wish to set these fields to empty strings
-        if name is None and url is None:
-            raise ValueError(
-                'either `name` or `url` is required.')
-
-        constraints = ''
+        # MCF spec says use 'otherRestrictions' to mean no restrictions
+        constraints = 'otherRestrictions'
         if name or url:
             constraints = 'license'
 
@@ -552,10 +553,6 @@ class MetadataControl(object):
         jsonschema.validate(self.mcf, MCF_SCHEMA)
 
     def to_string(self):
-        pass
-
-    def _set_content_info(self):
-        """Populate the MCF using properties of attributes of the dataset."""
         pass
 
     def _set_spatial_info(self):

--- a/src/geometamaker/geometamaker.py
+++ b/src/geometamaker/geometamaker.py
@@ -423,7 +423,7 @@ class MetadataControl(object):
         return self.mcf['identification'].get('purpose')
 
     def set_band_description(self, band_number, name=None, title=None, abstract=None,
-                             units=None, datatype=None, insert=False):
+                             units=None, type=None, insert=False):
         """Define metadata for a raster band.
 
         Args:
@@ -432,7 +432,7 @@ class MetadataControl(object):
             title (str): title for the raster band
             abstract (str): description of the raster band
             units (str): unit of measurement for the band's pixel values
-            datatype (str): of the band's values, either 'integer' or 'number'
+            type (str): of the band's values, either 'integer' or 'number'
         """
         idx = band_number - 1
         try:
@@ -460,10 +460,20 @@ class MetadataControl(object):
             attribute['abstract'] = abstract
         if units is not None:
             attribute['units'] = units
-        if datatype is not None:
-            attribute['type'] = datatype
+        # TODO: I don't like using `type` as the argname,
+        # but that is the name of the MCF property, and making
+        # the setter's argnames match makes it convenient to do things
+        # like mc_a.set_band_description(1, **mc_b.get_band_description(1))
+        if type is not None:
+            attribute['type'] = type
 
         self.mcf['content_info']['attributes'][idx] = attribute
+        # TODO: cannot validate entire MCF here because this setter
+        # is called as part of the init process before other required MCF
+        # properties are set. Solutions could be to make create_band_description()
+        # and create_field_description() methods instead of calling these setters.
+        # Or figure out how to validate just one section of the MCF.
+        # self.validate()
 
     def get_band_description(self, band_number):
         """Get the attribute metadata for a band.
@@ -484,7 +494,7 @@ class MetadataControl(object):
             f'{self.datasource} has no attribute named {name}')
 
     def set_field_description(self, name, title=None, abstract=None,
-                              units=None, datatype=None, insert=False):
+                              units=None, type=None, insert=False):
         """Define metadata for a tabular field.
 
         Args:
@@ -516,10 +526,12 @@ class MetadataControl(object):
             attribute['abstract'] = abstract
         if units is not None:
             attribute['units'] = units
-        if datatype is not None:
-            attribute['type'] = datatype
+        if type is not None:
+            attribute['type'] = type
 
         self.mcf['content_info']['attributes'][idx] = attribute
+        # TODO: see comment in set_band_description
+        # self.validate()
 
     def get_field_description(self, name):
         """Get the attribute metadata for a field.
@@ -617,7 +629,7 @@ class MetadataControl(object):
                         f'{field.name} will be "object".')
                     datatype = 'object'
                 self.set_field_description(
-                    field.name, datatype=datatype, insert=True)
+                    field.name, type=datatype, insert=True)
             #     attribute = {}
             #     attribute['name'] = field.name
             #     try:
@@ -650,7 +662,7 @@ class MetadataControl(object):
                 datatype = 'integer' if band.DataType < 6 else 'number'
                 abstract = band.GetDescription()
                 self.set_band_description(
-                    b, datatype=datatype, abstract=abstract, insert=True)
+                    b, type=datatype, abstract=abstract, insert=True)
             band = None
             raster = None
 

--- a/src/geometamaker/geometamaker.py
+++ b/src/geometamaker/geometamaker.py
@@ -433,9 +433,6 @@ class MetadataControl(object):
             abstract (str): description of the raster band
             units (str): unit of measurement for the band's pixel values
             type (str): of the band's values, either 'integer' or 'number'
-        Raises:
-            IndexError if MCF attributes do not contain an element for
-            the corresponding ``band_number``.
 
         """
         idx = band_number - 1
@@ -495,8 +492,6 @@ class MetadataControl(object):
             abstract (str): description of the field
             units (str): unit of measurement for the field's values
 
-        Raises:
-            KeyError if MCF does not contain an attribute with ``name``
         """
         idx, attribute = self._get_attr(name)
 
@@ -578,7 +573,8 @@ class MetadataControl(object):
             self.mcf['spatial']['datatype'] = 'vector'
             self.mcf['content_info']['type'] = 'coverage'
 
-            vector = gdal.OpenEx(self.datasource, gdal.OF_VECTOR)
+            vector = gdal.OpenEx(self.datasource, gdal.OF_VECTOR,
+                                 open_options=['AUTODETECT_TYPE=YES'])
             layer = vector.GetLayer()
             layer_defn = layer.GetLayerDefn()
             geomname = ogr.GeometryTypeToName(layer_defn.GetGeomType())

--- a/src/geometamaker/geometamaker.py
+++ b/src/geometamaker/geometamaker.py
@@ -461,6 +461,20 @@ class MetadataControl(object):
         return self.mcf['content_info']['attributes'][band_number - 1]
 
     def _get_attr(self, name):
+        """Get an attribute by its name property.
+
+        Args:
+            name (string): to match the value of the 'name' key in a dict
+
+        Returns:
+            tuple of (list index of the matching attribute, the attribute
+                dict)
+
+        Raises:
+            KeyError if no attributes exist in the MCF or if the named
+                attribute does not exist.
+
+        """
         if len(self.mcf['content_info']['attributes']) == 0:
             raise KeyError(
                 f'{self.datasource} MCF has not attributes')
@@ -519,12 +533,6 @@ class MetadataControl(object):
         - 'myraster.tif'
         - 'myraster.tif.yml'
         - 'myraster.tif.xml'
-
-        Args:
-            schema (str): name of a metadata schema supported by pygeometa.
-
-        Returns:
-            None
 
         """
         self.mcf['metadata']['datestamp'] = datetime.utcnow().strftime(

--- a/src/geometamaker/geometamaker.py
+++ b/src/geometamaker/geometamaker.py
@@ -347,7 +347,7 @@ class MetadataControl(object):
     def get_keywords(self, section='default'):
         return self.mcf['identification']['keywords'][section]
 
-    def set_license(self, license_name=None, license_url=None):
+    def set_license(self, name=None, url=None):
         """Add a license for the dataset.
 
         Args:
@@ -355,17 +355,17 @@ class MetadataControl(object):
 
         """
         # One may wish to set these fields to empty strings
-        if license_name is None and license_url is None:
+        if name is None and url is None:
             raise ValueError(
-                'either `license_name` or `license_url` is required.')
+                'either `name` or `url` is required.')
 
         constraints = ''
-        if license_name or license_url:
+        if name or url:
             constraints = 'license'
 
         license_dict = {}
-        license_dict['name'] = license_name if license_name else ''
-        license_dict['url'] = license_url if license_url else ''
+        license_dict['name'] = name if name else ''
+        license_dict['url'] = url if url else ''
         self.mcf['identification']['license'] = license_dict
         self.mcf['identification']['accessconstraints'] = constraints
         self.validate()

--- a/tests/data/template.yml
+++ b/tests/data/template.yml
@@ -13,8 +13,6 @@ contact:
     postalcode: ''
     url: ''
 content_info:
-  attributes:
-  - name: ''
   dimensions:
   - max: 0.0
     min: 0.0

--- a/tests/test_geometamaker.py
+++ b/tests/test_geometamaker.py
@@ -290,6 +290,16 @@ class MetadataControlTests(unittest.TestCase):
         self.assertEqual(attr['abstract'], abstract)
         self.assertEqual(attr['units'], units)
 
+    def test_set_abstract(self):
+        """MetadataControl: set and get an abstract."""
+
+        from geometamaker import MetadataControl
+
+        abstract = 'foo bar'
+        mc = MetadataControl()
+        mc.set_abstract(abstract)
+        self.assertEqual(mc.get_abstract(), abstract)
+
     def test_set_contact(self):
         """MetadataControl: set and get a contact section."""
 
@@ -435,12 +445,24 @@ class MetadataControlTests(unittest.TestCase):
         mc = MetadataControl(datasource_path)
         name = 'CC-BY-4.0'
         url = 'https://creativecommons.org/licenses/by/4.0/'
+
         mc.set_license(name=name)
+        self.assertEqual(
+            mc.mcf['identification']['accessconstraints'],
+            'license')
         self.assertEqual(mc.get_license(), {'name': name, 'url': ''})
+
         mc.set_license(url=url)
         self.assertEqual(mc.get_license(), {'name': '', 'url': url})
+
         mc.set_license(name=name, url=url)
         self.assertEqual(mc.get_license(), {'name': name, 'url': url})
+
+        mc.set_license()
+        self.assertEqual(mc.get_license(), {'name': '', 'url': ''})
+        self.assertEqual(
+            mc.mcf['identification']['accessconstraints'],
+            'otherRestrictions')
 
     def test_set_license_validates(self):
         """MetadataControl: test set license raises ValidationError."""

--- a/tests/test_geometamaker.py
+++ b/tests/test_geometamaker.py
@@ -492,8 +492,8 @@ class MetadataControlTests(unittest.TestCase):
         mc.set_purpose(purpose)
         self.assertEqual(mc.get_purpose(), purpose)
 
-    def test_preexisting_mc(self):
-        """MetadataControl: test reading and ammending an existing MetadataControl."""
+    def test_preexisting_mc_raster(self):
+        """MetadataControl: test reading and ammending an existing MCF raster."""
         from geometamaker import MetadataControl
 
         title = 'Title'
@@ -509,12 +509,37 @@ class MetadataControlTests(unittest.TestCase):
         new_mc = MetadataControl(datasource_path)
         new_mc.set_keywords([keyword])
 
+        self.assertEqual(new_mc.mcf['metadata']['hierarchylevel'], 'dataset')
         self.assertEqual(
             new_mc.get_title(), title)
         self.assertEqual(
             new_mc.get_band_description(1)['name'], band_name)
         self.assertEqual(
             new_mc.get_keywords()['keywords'], [keyword])
+
+    def test_preexisting_mc_vector(self):
+        """MetadataControl: test reading and ammending an existing MCF vector."""
+        from geometamaker import MetadataControl
+
+        title = 'Title'
+        datasource_path = os.path.join(self.workspace_dir, 'vector.geojson')
+        field_name = 'foo'
+        description = 'description'
+        field_map = {
+            field_name: list(_OGR_TYPES_VALUES_MAP)[0]}
+        create_vector(datasource_path, field_map)
+        mc = MetadataControl(datasource_path)
+        mc.set_title(title)
+        mc.set_field_description(field_name, abstract=description)
+        mc.write()
+
+        new_mc = MetadataControl(datasource_path)
+
+        self.assertEqual(new_mc.mcf['metadata']['hierarchylevel'], 'dataset')
+        self.assertEqual(
+            new_mc.get_title(), title)
+        self.assertEqual(
+            new_mc.get_field_description(field_name)['abstract'], description)
 
     def test_invalid_preexisting_mcf(self):
         """MetadataControl: test overwriting an existing invalid MetadataControl."""

--- a/tests/test_geometamaker.py
+++ b/tests/test_geometamaker.py
@@ -118,8 +118,8 @@ class MetadataControlTests(unittest.TestCase):
         from geometamaker import MetadataControl
 
         datasource_path = os.path.join(self.workspace_dir, 'data.csv')
-        field_names = ['Strings', 'Numbers', 'Booleans']
-        field_values = ['foo', 1, True]
+        field_names = ['Strings', 'Ints', 'Reals']
+        field_values = ['foo', 1, 0.9]
         with open(datasource_path, 'w') as file:
             writer = csv.writer(file)
             writer.writerow(field_names)
@@ -135,6 +135,9 @@ class MetadataControlTests(unittest.TestCase):
         self.assertEqual(
             len(mc.mcf['content_info']['attributes']),
             len(field_names))
+        self.assertEqual(mc.get_field_description('Strings')['type'], 'string')
+        self.assertEqual(mc.get_field_description('Ints')['type'], 'integer')
+        self.assertEqual(mc.get_field_description('Reals')['type'], 'number')
 
         title = 'title'
         abstract = 'some abstract'

--- a/tests/test_geometamaker.py
+++ b/tests/test_geometamaker.py
@@ -436,11 +436,11 @@ class MetadataControlTests(unittest.TestCase):
         mc = MetadataControl(datasource_path)
         name = 'CC-BY-4.0'
         url = 'https://creativecommons.org/licenses/by/4.0/'
-        mc.set_license(license_name=name)
+        mc.set_license(name=name)
         self.assertEqual(mc.get_license(), {'name': name, 'url': ''})
-        mc.set_license(license_url=url)
+        mc.set_license(url=url)
         self.assertEqual(mc.get_license(), {'name': '', 'url': url})
-        mc.set_license(license_name=name, license_url=url)
+        mc.set_license(name=name, url=url)
         self.assertEqual(mc.get_license(), {'name': name, 'url': url})
 
     def test_set_license_validates(self):
@@ -453,9 +453,9 @@ class MetadataControlTests(unittest.TestCase):
         mc = MetadataControl(datasource_path)
         name = 4.0  # should be a string
         with self.assertRaises(ValidationError):
-            mc.set_license(license_name=name)
+            mc.set_license(name=name)
         with self.assertRaises(ValidationError):
-            mc.set_license(license_url=name)
+            mc.set_license(url=name)
 
     def test_set_and_get_lineage(self):
         """MetadataControl: set lineage of dataset."""

--- a/tests/test_geometamaker.py
+++ b/tests/test_geometamaker.py
@@ -498,20 +498,23 @@ class MetadataControlTests(unittest.TestCase):
 
         title = 'Title'
         keyword = 'foo'
+        band_name = 'The Band'
         datasource_path = os.path.join(self.workspace_dir, 'raster.tif')
         create_raster(numpy.int16, datasource_path)
         mc = MetadataControl(datasource_path)
         mc.set_title(title)
+        mc.set_band_description(1, name=band_name)
         mc.write()
 
         new_mc = MetadataControl(datasource_path)
         new_mc.set_keywords([keyword])
 
         self.assertEqual(
-            new_mc.mcf['identification']['title'], title)
+            new_mc.get_title(), title)
         self.assertEqual(
-            new_mc.mcf['identification']['keywords']['default']['keywords'],
-            [keyword])
+            new_mc.get_band_description(1)['name'], band_name)
+        self.assertEqual(
+            new_mc.get_keywords()['keywords'], [keyword])
 
     def test_invalid_preexisting_mcf(self):
         """MetadataControl: test overwriting an existing invalid MetadataControl."""


### PR DESCRIPTION
This PR adds support for `.csv` files, by treating them like other vector datasets that GDAL supports.

A couple other things here:
* Debugged some issues with overwriting existing MCF data when a `MetadataControl` is initialized. The goal is to preserve any metadata that might already exist, except for properties that are intrinsic to the dataset (i.e. CRS, bounding box, field names & datatypes).
* changed some function keyword arg names to match the names of the MCF properties they represent. This makes it easy to use a pattern like `mc_a.set_license(**mc_b.get_license())`