### PR TITLE
pass GDAL open_options that are appropriate for the vector format

### DIFF
--- a/src/geometamaker/geometamaker.py
+++ b/src/geometamaker/geometamaker.py
@@ -561,15 +561,20 @@ class MetadataControl(object):
         self.mcf['metadata']['hierarchylevel'] = 'dataset'
 
         if gis_type == pygeoprocessing.VECTOR_TYPE:
-            self.mcf['spatial']['datatype'] = 'vector'
             self.mcf['content_info']['type'] = 'coverage'
+            self.mcf['spatial']['datatype'] = 'vector'
+            open_options = []
+
+            if os.path.splitext(self.datasource)[1] == '.csv':
+                self.mcf['spatial']['datatype'] = 'textTable'
+                open_options.append('AUTODETECT_TYPE=YES')
 
             vector = gdal.OpenEx(self.datasource, gdal.OF_VECTOR,
-                                 open_options=['AUTODETECT_TYPE=YES'])
+                                 open_options=open_options)
             layer = vector.GetLayer()
             layer_defn = layer.GetLayerDefn()
             geomname = ogr.GeometryTypeToName(layer_defn.GetGeomType())
-            geomtype = ''
+            geomtype = NO_GEOM_TYPE
             # https://www.fgdc.gov/nap/metadata/register/codelists.html
             if 'Point' in geomname:
                 geomtype = 'point'
@@ -640,27 +645,21 @@ class MetadataControl(object):
 
             gis_info = pygeoprocessing.get_raster_info(self.datasource)
 
-        if os.path.splitext(self.datasource)[1] == '.csv':
-            # These properties are required by MCF, even if the CSV
-            # in question is not spatial at all.
-            self.mcf['spatial']['geomtype'] = NO_GEOM_TYPE
-            self.mcf['spatial']['datatype'] = 'textTable'
-            return
-
-        try:
-            srs = osr.SpatialReference()
-            srs.ImportFromWkt(gis_info['projection_wkt'])
-            epsg = srs.GetAttrValue('AUTHORITY', 1)
-        except TypeError:
-            LOGGER.warning(
-                f'could not import a spatial reference system from '
-                f'"projection_wkt" in {gis_info}')
-            epsg = ''
-        # for human-readable values after yaml dump, use python types
-        # instead of numpy types
-        bbox = [float(x) for x in gis_info['bounding_box']]
-        spatial_info = [{
-            'bbox': bbox,
-            'crs': epsg  # MCF does not support WKT here
-        }]
-        self.mcf['identification']['extents']['spatial'] = spatial_info
+        if gis_info['projection_wkt']:
+            try:
+                srs = osr.SpatialReference()
+                srs.ImportFromWkt(gis_info['projection_wkt'])
+                epsg = srs.GetAttrValue('AUTHORITY', 1)
+            except TypeError:
+                LOGGER.warning(
+                    f'could not import a spatial reference system from '
+                    f'"projection_wkt" in {gis_info}')
+                epsg = ''
+            # for human-readable values after yaml dump, use python types
+            # instead of numpy types
+            bbox = [float(x) for x in gis_info['bounding_box']]
+            spatial_info = [{
+                'bbox': bbox,
+                'crs': epsg  # MCF does not support WKT here
+            }]
+            self.mcf['identification']['extents']['spatial'] = spatial_info

--- a/tests/test_geometamaker.py
+++ b/tests/test_geometamaker.py
@@ -14,6 +14,7 @@ from osgeo import osr
 from pygeometa.core import MCFValidationError
 import pygeoprocessing
 from pygeoprocessing.geoprocessing_core import DEFAULT_GTIFF_CREATION_TUPLE_OPTIONS
+import pytest
 import shapely
 import yaml
 
@@ -34,7 +35,7 @@ _OGR_TYPES_VALUES_MAP = {
 }
 
 
-def create_vector(target_filepath, field_map=None):
+def create_vector(target_filepath, field_map=None, driver='GEOJSON'):
     attribute_list = None
     if field_map:
         attribute_list = [{
@@ -47,7 +48,7 @@ def create_vector(target_filepath, field_map=None):
         [shapely.geometry.Point(1, -1)],
         target_filepath,
         projection.ExportToWkt(),
-        'GEOJSON',
+        driver,
         fields=field_map,
         attribute_list=attribute_list,
         ogr_geom_type=ogr.wkbPoint)
@@ -163,15 +164,17 @@ class MetadataControlTests(unittest.TestCase):
         self.assertEqual(attr['abstract'], abstract)
         self.assertEqual(attr['units'], units)
 
-    def test_vector_MetadataControl(self):
-        """MetadataControl: validate basic vector MetadataControl."""
+    def test_bad_csv_MetadataControl(self):
+        """MetadataControl: validate basic csv MetadataControl."""
         from geometamaker import MetadataControl
 
-        datasource_path = os.path.join(self.workspace_dir, 'vector.geojson')
-        field_map = {
-            f'field_{k}': k
-            for k in _OGR_TYPES_VALUES_MAP}
-        create_vector(datasource_path, field_map)
+        datasource_path = os.path.join('data.csv')
+        field_names = ['Strings', 'Ints', 'Reals']
+        field_values = ['foo', 1, 0.9, 'extra']
+        with open(datasource_path, 'w') as file:
+            writer = csv.writer(file)
+            writer.writerow(field_names)
+            writer.writerow(field_values)
 
         mc = MetadataControl(datasource_path)
         try:
@@ -181,6 +184,34 @@ class MetadataControlTests(unittest.TestCase):
                 'unexpected validation error occurred\n'
                 f'{e}')
         mc.write()
+        self.assertEqual(
+            len(mc.mcf['content_info']['attributes']),
+            len(field_names))
+        self.assertEqual(mc.get_field_description('Strings')['type'], 'string')
+        self.assertEqual(mc.get_field_description('Ints')['type'], 'integer')
+        self.assertEqual(mc.get_field_description('Reals')['type'], 'number')
+
+    def test_vector_MetadataControl(self):
+        """MetadataControl: validate basic vector MetadataControl."""
+        from geometamaker import MetadataControl
+
+        field_map = {
+            f'field_{k}': k
+            for k in _OGR_TYPES_VALUES_MAP}
+        for driver, ext in [('GEOJSON', 'geojson'), ('ESRI Shapefile', 'shp')]:
+            with self.subTest(driver=driver, ext=ext):
+                datasource_path = os.path.join(
+                    self.workspace_dir, f'vector.{ext}')
+                create_vector(datasource_path, field_map, driver)
+
+                mc = MetadataControl(datasource_path)
+                try:
+                    mc.validate()
+                except (MCFValidationError, SchemaError) as e:
+                    self.fail(
+                        'unexpected validation error occurred\n'
+                        f'{e}')
+                mc.write()
 
     def test_vector_no_fields(self):
         """MetadataControl: validate MetadataControl for basic vector with no fields."""

--- a/tests/test_geometamaker.py
+++ b/tests/test_geometamaker.py
@@ -14,7 +14,6 @@ from osgeo import osr
 from pygeometa.core import MCFValidationError
 import pygeoprocessing
 from pygeoprocessing.geoprocessing_core import DEFAULT_GTIFF_CREATION_TUPLE_OPTIONS
-import pytest
 import shapely
 import yaml
 
@@ -198,7 +197,10 @@ class MetadataControlTests(unittest.TestCase):
         field_map = {
             f'field_{k}': k
             for k in _OGR_TYPES_VALUES_MAP}
-        for driver, ext in [('GEOJSON', 'geojson'), ('ESRI Shapefile', 'shp')]:
+        for driver, ext in [
+                ('GEOJSON', 'geojson'),
+                ('ESRI Shapefile', 'shp'),
+                ('GPKG', 'gpkg')]:
             with self.subTest(driver=driver, ext=ext):
                 datasource_path = os.path.join(
                     self.workspace_dir, f'vector.{ext}')
@@ -212,6 +214,7 @@ class MetadataControlTests(unittest.TestCase):
                         'unexpected validation error occurred\n'
                         f'{e}')
                 mc.write()
+                self.assertTrue(os.path.exists(f'{datasource_path}.yml'))
 
     def test_vector_no_fields(self):
         """MetadataControl: validate MetadataControl for basic vector with no fields."""

--- a/tests/test_geometamaker.py
+++ b/tests/test_geometamaker.py
@@ -164,7 +164,7 @@ class MetadataControlTests(unittest.TestCase):
         self.assertEqual(attr['units'], units)
 
     def test_bad_csv_MetadataControl(self):
-        """MetadataControl: validate basic csv MetadataControl."""
+        """MetadataControl: CSV with extra item in row does not fail."""
         from geometamaker import MetadataControl
 
         datasource_path = os.path.join('data.csv')


### PR DESCRIPTION
Fixes #16 

This PR adds tests that use a few common GDAL vector formats. And it fixes the issue where `open_options` that we want to use for CSVs were also being applied to other formats. GDAL would ignore them but issue a warning.