### PR TITLE
Add url, citation, doi metadata properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,3 +50,6 @@ for path, dirs, files in os.walk(data_dir):
             mc.validate()
             mc.write()
 ```
+
+#### For a complete list of methods:
+https://geometamaker.readthedocs.io/en/latest/api/geometamaker.html

--- a/src/geometamaker/geometamaker.py
+++ b/src/geometamaker/geometamaker.py
@@ -36,6 +36,12 @@ with open(MCF_SCHEMA_FILE, 'r') as schema_file:
 MCF_SCHEMA['required'].append('content_info')
 MCF_SCHEMA['required'].append('dataquality')
 MCF_SCHEMA['properties']['identification']['properties'][
+    'citation'] = {
+        'type': 'string',
+        'description': 'a biobliographic citation for the dataset'
+    }
+MCF_SCHEMA['properties']['identification']['required'].append('citation')
+MCF_SCHEMA['properties']['identification']['properties'][
     'keywords']['patternProperties']['^.*'][
     'required'] = ['keywords', 'keywords_type']
 # to accomodate tables that do not represent spatial content:

--- a/src/geometamaker/geometamaker.py
+++ b/src/geometamaker/geometamaker.py
@@ -463,6 +463,19 @@ class MetadataControl(object):
         """
         return self.mcf['identification'].get('purpose')
 
+    def set_url(self, url):
+        """Add a url for the dataset.
+
+        Args:
+            url (str)
+
+        """
+        self.mcf['identification']['url'] = url
+
+    def get_url(self):
+        """Get the url for the dataset."""
+        return self.mcf['identification']['url']
+
     def set_band_description(self, band_number, name=None, title=None,
                              abstract=None, units=None, type=None):
         """Define metadata for a raster band.

--- a/src/geometamaker/geometamaker.py
+++ b/src/geometamaker/geometamaker.py
@@ -266,6 +266,19 @@ class MetadataControl(object):
         """Get the abstract for the dataset."""
         return self.mcf['identification']['abstract']
 
+    def set_citation(self, citation):
+        """Add a citation string for the dataset.
+
+        Args:
+            citation (str)
+
+        """
+        self.mcf['identification']['citation'] = citation
+
+    def get_citation(self):
+        """Get the citation for the dataset."""
+        return self.mcf['identification']['citation']
+
     def set_contact(self, organization=None, individualname=None, positionname=None,
                     email=None, section='default', **kwargs):
         """Add a contact section.
@@ -307,6 +320,19 @@ class MetadataControl(object):
 
         """
         return self.mcf['contact'].get(section)
+
+    def set_doi(self, doi):
+        """Add a doi string for the dataset.
+
+        Args:
+            doi (str)
+
+        """
+        self.mcf['identification']['doi'] = doi
+
+    def get_doi(self):
+        """Get the doi for the dataset."""
+        return self.mcf['identification']['doi']
 
     def set_edition(self, edition):
         """Set the edition for the dataset.

--- a/tests/data/template.yml
+++ b/tests/data/template.yml
@@ -34,6 +34,7 @@ distribution:
 identification:
   abstract: ''
   accessconstraints: ''
+  citation: ''
   dates:
     creation: ''
     publication: ''

--- a/tests/test_geometamaker.py
+++ b/tests/test_geometamaker.py
@@ -341,6 +341,16 @@ class MetadataControlTests(unittest.TestCase):
         mc.set_abstract(abstract)
         self.assertEqual(mc.get_abstract(), abstract)
 
+    def test_set_citation(self):
+        """MetadataControl: set and get a citation."""
+
+        from geometamaker import MetadataControl
+
+        citation = 'foo bar'
+        mc = MetadataControl()
+        mc.set_citation(citation)
+        self.assertEqual(mc.get_citation(), citation)
+
     def test_set_contact(self):
         """MetadataControl: set and get a contact section."""
 
@@ -395,6 +405,16 @@ class MetadataControlTests(unittest.TestCase):
         mc = MetadataControl(datasource_path)
         with self.assertRaises(ValidationError):
             mc.set_contact(postalcode=postalcode)
+
+    def test_set_doi(self):
+        """MetadataControl: set and get a doi."""
+
+        from geometamaker import MetadataControl
+
+        doi = '10.foo/bar'
+        mc = MetadataControl()
+        mc.set_doi(doi)
+        self.assertEqual(mc.get_doi(), doi)
 
     def test_set_get_edition(self):
         """MetadataControl: set and get dataset edition."""

--- a/tests/test_geometamaker.py
+++ b/tests/test_geometamaker.py
@@ -574,6 +574,16 @@ class MetadataControlTests(unittest.TestCase):
         mc.set_purpose(purpose)
         self.assertEqual(mc.get_purpose(), purpose)
 
+    def test_set_url(self):
+        """MetadataControl: set and get a url."""
+
+        from geometamaker import MetadataControl
+
+        url = 'http://foo/bar'
+        mc = MetadataControl()
+        mc.set_url(url)
+        self.assertEqual(mc.get_url(), url)
+
     def test_preexisting_mc_raster(self):
         """MetadataControl: test reading and ammending an existing MCF raster."""
         from geometamaker import MetadataControl


### PR DESCRIPTION
Fixes #17 

`url` and `doi` appear in the `identification` section of the core MCF spec, with `url` being a required property (it can be blank). `citation` does not appear in the MCF spec, but I added it here, also in the `identification` section.