### PR TITLE
improve an error message.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12"]
         os: [ubuntu-latest, windows-latest, macos-latest]
 
     steps:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = "geometamaker"
 description = "metadata creation for geospatial data"
 readme = "README.md"
-requires-python = ">=3.8,<3.13"
+requires-python = ">=3.10,<3.13"
 license = {file = "LICENSE.txt"}
 maintainers = [
     {name = "Natural Capital Project Software Team"}
@@ -17,8 +17,6 @@ classifiers = [
     "Operating System :: Microsoft",
     "Operating System :: POSIX",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.8",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",

--- a/src/geometamaker/geometamaker.py
+++ b/src/geometamaker/geometamaker.py
@@ -34,13 +34,15 @@ def detect_file_type(filepath):
         return 'table'
     if desc.compression:
         return 'archive'
-    gis_type = pygeoprocessing.get_gis_type(filepath)
+    try:
+        gis_type = pygeoprocessing.get_gis_type(filepath)
+    except ValueError:
+        raise ValueError(
+            f'{filepath} does not appear to be one of (archive, table, raster, vector)')
     if gis_type == pygeoprocessing.VECTOR_TYPE:
         return 'vector'
     if gis_type == pygeoprocessing.RASTER_TYPE:
         return 'raster'
-    raise ValueError(
-        f'{filepath} does not appear to be one of (archive, table, raster, vector)')
 
 
 def describe_archive(source_dataset_path):

--- a/src/geometamaker/geometamaker.py
+++ b/src/geometamaker/geometamaker.py
@@ -20,8 +20,11 @@ def detect_file_type(filepath):
     Args:
         filepath (str): path to a file to be opened by GDAL or frictionless
 
-    Returns
+    Returns:
         str
+
+    Raises:
+        ValueError on unsupported file formats.
 
     """
     # TODO: guard against classifying netCDF, HDF5, etc as GDAL rasters.
@@ -43,6 +46,12 @@ def detect_file_type(filepath):
         return 'vector'
     if gis_type == pygeoprocessing.RASTER_TYPE:
         return 'raster'
+    raise ValueError(
+        f'{filepath} contains both raster and vector data. '
+        'Such files are not supported by GeoMetaMaker. '
+        'If you wish to see support for these files, please '
+        'submit a feature request and share your dataset: '
+        'https://github.com/natcap/geometamaker/issues ')
 
 
 def describe_archive(source_dataset_path):

--- a/tests/test_geometamaker.py
+++ b/tests/test_geometamaker.py
@@ -100,6 +100,20 @@ class MetadataControlTests(unittest.TestCase):
         with self.assertRaises(FileNotFoundError):
             _ = geometamaker.describe('foo.tif')
 
+    def test_unsupported_file_format(self):
+        """Raises exception if given file format is not supported."""
+        import geometamaker
+
+        filepath = os.path.join(self.workspace_dir, 'foo.html')
+        with open(filepath, 'w') as file:
+            file.write('<html />')
+
+        with self.assertRaises(ValueError) as cm:
+            _ = geometamaker.describe(filepath)
+        actual_message = str(cm.exception)
+        expected_message = 'does not appear to be one of'
+        self.assertIn(expected_message, actual_message)
+
     def test_describe_csv(self):
         """Test setting properties on csv."""
         import geometamaker


### PR DESCRIPTION
Fixes #31 

I also removed the test runs for Python 3.8 and 3.9 because we decided during #24 that it's okay to use `dataclasses` features that were introduced in 3.10.