### PR TITLE
better handle remote files by avoiding full reads

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,9 +28,6 @@ classifiers = [
 # using the corresponding setup args `install_requires` and `extras_require`
 dynamic = ["version", "dependencies", "optional-dependencies"]
 
-[project.scripts]
-geometamaker = "geometamaker.cli:main"
-
 [build-system]
 requires = ["setuptools >= 40.6.0", "wheel", "setuptools_scm"]
 build-backend = "setuptools.build_meta"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,9 @@ classifiers = [
 # using the corresponding setup args `install_requires` and `extras_require`
 dynamic = ["version", "dependencies", "optional-dependencies"]
 
+[project.scripts]
+geometamaker = "geometamaker.cli:main"
+
 [build-system]
 requires = ["setuptools >= 40.6.0", "wheel", "setuptools_scm"]
 build-backend = "setuptools.build_meta"

--- a/src/geometamaker/geometamaker.py
+++ b/src/geometamaker/geometamaker.py
@@ -15,7 +15,7 @@ from . import models
 
 LOGGER = logging.getLogger(__name__)
 
-# URI schemes we support, a subset of fsspec.available_protocols()
+# URI schemes we support. A subset of fsspec.available_protocols()
 PROTOCOLS = [
     'file',
     'http',
@@ -171,7 +171,6 @@ def describe_raster(source_dataset_path, scheme):
 
     """
     description = describe_file(source_dataset_path)
-    LOGGER.debug('getting raster info')
     if 'http' in scheme:
         source_dataset_path = f'/vsicurl/{source_dataset_path}'
     info = pygeoprocessing.get_raster_info(source_dataset_path)
@@ -260,7 +259,6 @@ def describe(source_dataset_path):
 
     # Load existing metadata file
     try:
-        LOGGER.debug('loading existing metadata document')
         existing_resource = RESOURCE_MODELS[resource_type].load(metadata_path)
         if 'schema' in description:
             if isinstance(description['schema'], models.RasterSchema):

--- a/src/geometamaker/geometamaker.py
+++ b/src/geometamaker/geometamaker.py
@@ -1,5 +1,7 @@
 import dataclasses
+import hashlib
 import logging
+from datetime import datetime, timezone
 
 import frictionless
 import fsspec
@@ -13,8 +15,31 @@ from . import models
 
 LOGGER = logging.getLogger(__name__)
 
+# URI schemes we support, a subset of fsspec.available_protocols()
+PROTOCOLS = [
+    'file',
+    'http',
+    'https',
+]
 
-def detect_file_type(filepath):
+
+def _vsi_path(filepath, scheme):
+    """Construct a GDAL virtual file system path.
+
+    Args:
+        filepath (str): path to a file to be opened by GDAL
+        scheme (str): the protocol prefix of the filepath
+
+    Returns:
+        str
+
+    """
+    if 'http' in scheme:
+        filepath = f'/vsicurl/{filepath}'
+    return filepath
+
+
+def detect_file_type(filepath, scheme):
     """Detect the type of resource contained in the file.
 
     Args:
@@ -30,18 +55,20 @@ def detect_file_type(filepath):
     # TODO: guard against classifying netCDF, HDF5, etc as GDAL rasters.
     # We'll likely want a different data model for multi-dimensional arrays.
 
-    # GDAL considers CSV a vector, so check against frictionless
-    # first.
-    desc = frictionless.describe(filepath)
-    if desc.type == 'table':
+    # Frictionless supports a wide range of formats. The quickest way to
+    # determine if a file is recognized as a table or archive is to call list.
+    info = frictionless.list(filepath)[0]
+    if info.type == 'table':
         return 'table'
-    if desc.compression:
+    if info.compression:
         return 'archive'
+    # GDAL considers CSV a vector, so check against frictionless first.
     try:
-        gis_type = pygeoprocessing.get_gis_type(filepath)
+        gis_type = pygeoprocessing.get_gis_type(_vsi_path(filepath, scheme))
     except ValueError:
         raise ValueError(
-            f'{filepath} does not appear to be one of (archive, table, raster, vector)')
+            f'{filepath} does not appear to be one of '
+            f'(archive, table, raster, vector)')
     if gis_type == pygeoprocessing.VECTOR_TYPE:
         return 'vector'
     if gis_type == pygeoprocessing.RASTER_TYPE:
@@ -54,7 +81,38 @@ def detect_file_type(filepath):
         'https://github.com/natcap/geometamaker/issues ')
 
 
-def describe_archive(source_dataset_path):
+def describe_file(source_dataset_path):
+    """Describe basic properties of a file.
+
+    Args:
+        source_dataset_path (str): path to a file.
+
+    Returns:
+        dict
+
+    """
+    description = frictionless.describe(source_dataset_path).to_dict()
+    # Frictionless can retrieve stats like file size, but doing so necessarily
+    # computes a sha256 hash, which is too costly for remote or large files.
+    # So we use fsspec to get basic stats and construct a simple hash
+    of = fsspec.open(source_dataset_path)
+    info = of.fs.info(source_dataset_path)
+    description['bytes'] = info['size']
+    # files opened from http do not have mtime
+    try:
+        mtime = info['mtime']
+        description['last_modified'] = datetime.fromtimestamp(
+            mtime, tz=timezone.utc)
+    except KeyError:
+        mtime = ''
+    hash_func = hashlib.new('sha256')
+    hash_func.update(
+        f'{info["size"]}{mtime}{description["path"]}'.encode('ascii'))
+    description['uid'] = f'sizetimestamp:{hash_func.hexdigest()}'
+    return description
+
+
+def describe_archive(source_dataset_path, scheme=None):
     """Describe file properties of a compressed file.
 
     Args:
@@ -64,12 +122,11 @@ def describe_archive(source_dataset_path):
         dict
 
     """
-    description = frictionless.describe(
-        source_dataset_path, stats=True).to_dict()
+    description = describe_file(source_dataset_path)
     return description
 
 
-def describe_vector(source_dataset_path):
+def describe_vector(source_dataset_path, scheme):
     """Describe properties of a GDAL vector file.
 
     Args:
@@ -79,18 +136,19 @@ def describe_vector(source_dataset_path):
         dict
 
     """
-    description = frictionless.describe(
-        source_dataset_path, stats=True).to_dict()
-    fields = []
+    description = describe_file(source_dataset_path)
+
+    if 'http' in scheme:
+        source_dataset_path = f'/vsicurl/{source_dataset_path}'
     vector = gdal.OpenEx(source_dataset_path, gdal.OF_VECTOR)
     layer = vector.GetLayer()
-    description['rows'] = layer.GetFeatureCount()
+    fields = []
+    description['n_features'] = layer.GetFeatureCount()
     for fld in layer.schema:
         fields.append(
             models.FieldSchema(name=fld.name, type=fld.GetTypeName()))
     vector = layer = None
     description['schema'] = models.TableSchema(fields=fields)
-    description['fields'] = len(fields)
 
     info = pygeoprocessing.get_vector_info(source_dataset_path)
     spatial = {
@@ -102,7 +160,7 @@ def describe_vector(source_dataset_path):
     return description
 
 
-def describe_raster(source_dataset_path):
+def describe_raster(source_dataset_path, scheme):
     """Describe properties of a GDAL raster file.
 
     Args:
@@ -112,13 +170,12 @@ def describe_raster(source_dataset_path):
         dict
 
     """
-    description = frictionless.describe(
-        source_dataset_path, stats=True).to_dict()
-
-    bands = []
+    description = describe_file(source_dataset_path)
+    LOGGER.debug('getting raster info')
+    if 'http' in scheme:
+        source_dataset_path = f'/vsicurl/{source_dataset_path}'
     info = pygeoprocessing.get_raster_info(source_dataset_path)
-    # Some values of raster info are numpy types, which the
-    # yaml dumper doesn't know how to represent.
+    bands = []
     for i in range(info['n_bands']):
         b = i + 1
         bands.append(models.BandSchema(
@@ -130,6 +187,8 @@ def describe_raster(source_dataset_path):
         bands=bands,
         pixel_size=info['pixel_size'],
         raster_size=info['raster_size'])
+    # Some values of raster info are numpy types, which the
+    # yaml dumper doesn't know how to represent.
     description['spatial'] = models.SpatialSchema(
         bounding_box=[float(x) for x in info['bounding_box']],
         crs=info['projection_wkt'])
@@ -137,7 +196,7 @@ def describe_raster(source_dataset_path):
     return description
 
 
-def describe_table(source_dataset_path):
+def describe_table(source_dataset_path, scheme=None):
     """Describe properties of a tabular dataset.
 
     Args:
@@ -147,8 +206,7 @@ def describe_table(source_dataset_path):
         dict
 
     """
-    description = frictionless.describe(
-        source_dataset_path, stats=True).to_dict()
+    description = describe_file(source_dataset_path)
     description['schema'] = models.TableSchema(**description['schema'])
     return description
 
@@ -191,11 +249,18 @@ def describe(source_dataset_path):
     if not of.fs.exists(source_dataset_path):
         raise FileNotFoundError(f'{source_dataset_path} does not exist')
 
-    resource_type = detect_file_type(source_dataset_path)
-    description = DESRCIBE_FUNCS[resource_type](source_dataset_path)
+    protocol = fsspec.utils.get_protocol(source_dataset_path)
+    if protocol not in PROTOCOLS:
+        raise ValueError(
+            f'Cannot describe {source_dataset_path}. {protocol} '
+            f'is not one of the suppored file protocols: {PROTOCOLS}')
+    resource_type = detect_file_type(source_dataset_path, protocol)
+    description = DESRCIBE_FUNCS[resource_type](
+        source_dataset_path, protocol)
 
     # Load existing metadata file
     try:
+        LOGGER.debug('loading existing metadata document')
         existing_resource = RESOURCE_MODELS[resource_type].load(metadata_path)
         if 'schema' in description:
             if isinstance(description['schema'], models.RasterSchema):

--- a/src/geometamaker/geometamaker.py
+++ b/src/geometamaker/geometamaker.py
@@ -34,7 +34,7 @@ def _vsi_path(filepath, scheme):
         str
 
     """
-    if 'http' in scheme:
+    if scheme.startswith('http'):
         filepath = f'/vsicurl/{filepath}'
     return filepath
 

--- a/src/geometamaker/models.py
+++ b/src/geometamaker/models.py
@@ -148,16 +148,17 @@ class Resource:
     # A version string we can use to identify geometamaker compliant documents
     metadata_version: str = dataclasses.field(init=False)
 
-    # These are populated by `frictionless.describe()`
+    # These are populated by `frictionless.describe()` or fsspec info
     bytes: int = 0
     encoding: str = ''
     format: str = ''
-    hash: str = ''
+    uid: str = ''
     mediatype: str = ''
     name: str = ''
     path: str = ''
     scheme: str = ''
     type: str = ''
+    last_modified: str = ''
 
     # DataPackage includes `sources` as a list of source files
     # with some amount of metadata for each item. For our
@@ -441,8 +442,6 @@ class Resource:
 class TableResource(Resource):
     """Class for metadata for a table resource."""
 
-    fields: int
-    rows: int
     # without post-init, schema ends up as a dict, or whatever is passed in.
     schema: TableSchema = dataclasses.field(default_factory=TableSchema)
 
@@ -529,6 +528,7 @@ class ArchiveResource(Resource):
 class VectorResource(TableResource):
     """Class for metadata for a vector resource."""
 
+    n_features: int
     spatial: SpatialSchema
 
 

--- a/tests/test_geometamaker.py
+++ b/tests/test_geometamaker.py
@@ -82,7 +82,7 @@ def create_raster(
     raster = None
 
 
-class MetadataControlTests(unittest.TestCase):
+class GeometamakerTests(unittest.TestCase):
     """Tests for geometamaker."""
 
     def setUp(self):
@@ -501,3 +501,11 @@ class MetadataControlTests(unittest.TestCase):
         self.assertTrue(
             os.path.exists(os.path.join(
                 temp_dir, f'{os.path.basename(datasource_path)}.yml')))
+
+    def test_describe_remote_datasource(self):
+        """Test describe on a file at a public url."""
+        import geometamaker
+
+        filepath = 'https://storage.googleapis.com/natcap-data-cache/global/aster-v3-1s/aster-v3-1s.tif'
+        resource = geometamaker.describe(filepath)
+        self.assertEqual(resource.path, filepath)


### PR DESCRIPTION
A few metadata properties we are using required reading the entire dataset that is being described. This is okay for small, local files, but can become a problem for large, remote files. This PR updates or removes those properties so that describing a dataset remains quick.

**Properties changing:**

- `hash` -> `uid`: Instead of hashing a file to create a unique identifier, we now hash some properties of the file. I renamed to `uid` so that we do not mislead users into thinking this is a hash of the entire file.
- `rows` & `fields`: simply counting the number of rows in a table could be a problem, so this is no longer part of the metadata. Number of fields also seems unnecessary; all fields are still listed under the `schema`.
- `n_features`: a new property for vectors, instead of `rows`. It's already part of a GDAL vector metadata.

We also now use `vsicurl` when opening a remote file with GDAL. Opening with `http` seemed to download the whole file. Now geometamaker supports `http`, `https`, and local filesystem protocols, including networked drives. We could support other protocols in the future, but for now any others raise a helpful exception.

Fix #38 