### PR TITLE
Feature: metadata profiles and user-configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,7 @@ Supported datatypes include:
 
 See `requirements.txt` for dependencies
 
-### Usage patterns:
-
-#### Creating & adding metadata to file:
+### Creating & adding metadata to file:
 
 ```python
 import geometamaker
@@ -40,7 +38,7 @@ resource.set_band_description(
 resource.write()
 ```
 
-#### Creating metadata for a batch of files:
+### Creating metadata for a batch of files:
 ```python
 import os
 
@@ -58,17 +56,17 @@ for path, dirs, files in os.walk(data_dir):
         resource.write()
 ```
 
-#### Configuring default values for metadata properties:
+### Configuring default values for metadata properties:
 
 Users can create a "profile" that will apply some common properties
-to all datasets they describe. Profiles can include "contact" information
-and/or "license" information.
+to all datasets they describe. Profiles can include `contact` information
+and/or `license` information.
 
 A profile can be saved to a configuration file so that it will be re-used
 everytime you use `geometamaker`. In addition, users can set a profile
-during runtime, which takes precedence over a profile in the configuration file.
+during runtime, which takes precedence over a profile in the config file.
 
-##### create & apply a Profile at runtime
+#### Create & apply a Profile at runtime
 ```python
 import os
 
@@ -91,7 +89,7 @@ data_path = 'data/watershed_gura.shp'
 resource = geometamaker.describe(data_path, profile=profile)
 ```
 
-##### store a Profile in user-configuration
+#### Store a Profile in user-configuration
 ```python
 import os
 
@@ -114,5 +112,5 @@ resource = geometamaker.describe(data_path)
 ```
 
 
-#### For a complete list of methods:
+### For a complete list of methods:
 https://geometamaker.readthedocs.io/en/latest/api/geometamaker.html

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Supported datatypes include:
 
 See `requirements.txt` for dependencies
 
-### Some usage patterns:
+### Usage patterns:
 
 #### Creating & adding metadata to file:
 
@@ -57,6 +57,62 @@ for path, dirs, files in os.walk(data_dir):
             print(err)
         resource.write()
 ```
+
+#### Configuring default values for metadata properties:
+
+Users can create a "profile" that will apply some common properties
+to all datasets they describe. Profiles can include "contact" information
+and/or "license" information.
+
+A profile can be saved to a configuration file so that it will be re-used
+everytime you use `geometamaker`. In addition, users can set a profile
+during runtime, which takes precedence over a profile in the configuration file.
+
+##### create & apply a Profile at runtime
+```python
+import os
+
+import geometamaker
+from geometamaker import models
+
+contact = {
+    'individual_name': 'bob'
+}
+license = {
+    'title': 'CC-BY-4'
+}
+
+# Two different ways for setting profile attributes:
+profile = models.Profile(contact=contact)  # keyword arguments
+profile.set_license(**license)             # `set_*` methods
+
+data_path = 'data/watershed_gura.shp'
+# Pass the profile to the `describe` function
+resource = geometamaker.describe(data_path, profile=profile)
+```
+
+##### store a Profile in user-configuration
+```python
+import os
+
+import geometamaker
+from geometamaker import models
+from geometamaker.config import Config
+
+contact = {
+    'individual_name': 'bob'
+}
+
+profile = models.Profile(contact=contact)
+config = Config()
+config.save(profile)
+
+data_path = 'data/watershed_gura.shp'
+# A profile saved in the user's configuration file does not
+# need to be passed to `describe`. It is always applied.
+resource = geometamaker.describe(data_path)
+```
+
 
 #### For a complete list of methods:
 https://geometamaker.readthedocs.io/en/latest/api/geometamaker.html

--- a/README.md
+++ b/README.md
@@ -95,14 +95,13 @@ import os
 
 import geometamaker
 from geometamaker import models
-from geometamaker.config import Config
 
 contact = {
     'individual_name': 'bob'
 }
 
 profile = models.Profile(contact=contact)
-config = Config()
+config = geometamaker.Config()
 config.save(profile)
 
 data_path = 'data/watershed_gura.shp'

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,7 @@ fsspec
 GDAL
 frictionless
 numpy
+platformdirs
 pygeoprocessing>=2.4.3
 pyyaml
 requests

--- a/src/geometamaker/__init__.py
+++ b/src/geometamaker/__init__.py
@@ -1,8 +1,8 @@
 import importlib.metadata
 
 from .geometamaker import describe
-from .config import init_config
-from .config import configure
+# from .config import init_config
+# from .config import configure
 
-init_config()
+# init_config()
 __version__ = importlib.metadata.version('geometamaker')

--- a/src/geometamaker/__init__.py
+++ b/src/geometamaker/__init__.py
@@ -1,6 +1,7 @@
 import importlib.metadata
 
 from .geometamaker import describe
+from .config import Config
 
 
 __version__ = importlib.metadata.version('geometamaker')

--- a/src/geometamaker/__init__.py
+++ b/src/geometamaker/__init__.py
@@ -1,7 +1,5 @@
 import importlib.metadata
 
 from .geometamaker import describe
-# from .config import init_config
-# from .config import configure
 
 __version__ = importlib.metadata.version('geometamaker')

--- a/src/geometamaker/__init__.py
+++ b/src/geometamaker/__init__.py
@@ -2,4 +2,5 @@ import importlib.metadata
 
 from .geometamaker import describe
 
+
 __version__ = importlib.metadata.version('geometamaker')

--- a/src/geometamaker/__init__.py
+++ b/src/geometamaker/__init__.py
@@ -4,5 +4,4 @@ from .geometamaker import describe
 # from .config import init_config
 # from .config import configure
 
-# init_config()
 __version__ = importlib.metadata.version('geometamaker')

--- a/src/geometamaker/__init__.py
+++ b/src/geometamaker/__init__.py
@@ -1,6 +1,22 @@
 import importlib.metadata
+import os
+
+import platformdirs
+import yaml
 
 from .geometamaker import describe
 
 
 __version__ = importlib.metadata.version('geometamaker')
+
+CONFIG_FILE = os.path.join(
+    platformdirs.user_config_dir(), 'geometamaker_profiles.yml')
+
+DEFAULT_PROFILES = {
+    'contact': None,
+    'license': None
+}
+
+if not os.path.exists(CONFIG_FILE):
+    with open(CONFIG_FILE, 'w') as file:
+        file.write(yaml.dump(DEFAULT_PROFILES))

--- a/src/geometamaker/__init__.py
+++ b/src/geometamaker/__init__.py
@@ -1,22 +1,8 @@
 import importlib.metadata
-import os
-
-import platformdirs
-import yaml
 
 from .geometamaker import describe
+from .config import init_config
+from .config import configure
 
-
+init_config()
 __version__ = importlib.metadata.version('geometamaker')
-
-CONFIG_FILE = os.path.join(
-    platformdirs.user_config_dir(), 'geometamaker_profiles.yml')
-
-DEFAULT_PROFILES = {
-    'contact': None,
-    'license': None
-}
-
-if not os.path.exists(CONFIG_FILE):
-    with open(CONFIG_FILE, 'w') as file:
-        file.write(yaml.dump(DEFAULT_PROFILES))

--- a/src/geometamaker/config.py
+++ b/src/geometamaker/config.py
@@ -7,14 +7,16 @@ import fsspec
 import platformdirs
 import yaml
 
+from . import models
+
 
 LOGGER = logging.getLogger(__name__)
 
 DEFAULT_CONFIG_PATH = os.path.join(
     platformdirs.user_config_dir(), 'geometamaker_profile.yml')
 DEFAULT_PROFILE = {
-    'contact': None,
-    'license': None
+    'contact': models.ContactSchema(),
+    'license': models.LicenseSchema()
 }
 
 

--- a/src/geometamaker/config.py
+++ b/src/geometamaker/config.py
@@ -17,8 +17,10 @@ class Config(object):
     def __init__(self, config_path=DEFAULT_CONFIG_PATH):
         """Load a Profile from a config file.
 
-        Use a default user profile if none given. Create
-        that default profile if necessary.
+        Use a default user profile if none given.
+
+        Args:
+            config_path (str): path to a local yaml file
 
         """
         self.config_path = config_path
@@ -37,14 +39,15 @@ class Config(object):
                 'It will be ignored. You may wish to delete() it.')
 
     def save(self, profile):
-        """Save a Profile as the default user profile.
+        """Save a Profile to a local config file.
 
         Args:
             profile (geometamaker.models.Profile)
         """
-        LOGGER.info(f'writing config to {self.config_path}')
+        LOGGER.info(f'writing profile to {self.config_path}')
         profile.write(self.config_path)
 
-    def delete(self, config_path=DEFAULT_CONFIG_PATH):
+    def delete(self):
+        """Delete the config file."""
         LOGGER.info(f'removing {self.config_path}')
-        os.remove(config_path)
+        os.remove(self.config_path)

--- a/src/geometamaker/config.py
+++ b/src/geometamaker/config.py
@@ -13,6 +13,7 @@ DEFAULT_CONFIG_PATH = os.path.join(
 
 
 class Config(object):
+    """Encapsulates user-settings such as a metadata Profile."""
 
     def __init__(self, config_path=DEFAULT_CONFIG_PATH):
         """Load a Profile from a config file.
@@ -37,6 +38,12 @@ class Config(object):
             LOGGER.warning(
                 f'{self.config_path} contains an inavlid profile. '
                 'It will be ignored. You may wish to delete() it.')
+
+    def __repr__(self):
+        """Represent config as a string."""
+        return (
+            f'{self.config_path}: \n'
+            f'{self.profile}')
 
     def save(self, profile):
         """Save a Profile to a local config file.

--- a/src/geometamaker/config.py
+++ b/src/geometamaker/config.py
@@ -41,9 +41,7 @@ class Config(object):
 
     def __repr__(self):
         """Represent config as a string."""
-        return (
-            f'{self.config_path}: \n'
-            f'{self.profile}')
+        return f'Config(config_path={self.config_path} profile={self.profile})'
 
     def save(self, profile):
         """Save a Profile to a local config file.

--- a/src/geometamaker/config.py
+++ b/src/geometamaker/config.py
@@ -30,11 +30,11 @@ class Config(object):
         try:
             self.profile = models.Profile.load(self.config_path)
         except FileNotFoundError as err:
-            LOGGER.debug(err)
+            LOGGER.debug('config file does not exist', exc_info=err)
             pass
         # an invalid profile should raise a TypeError
         except TypeError as err:
-            LOGGER.warning(err)
+            LOGGER.warning('', exc_info=err)
             LOGGER.warning(
                 f'{self.config_path} contains an inavlid profile. '
                 'It will be ignored. You may wish to delete() it.')

--- a/src/geometamaker/config.py
+++ b/src/geometamaker/config.py
@@ -14,10 +14,6 @@ LOGGER = logging.getLogger(__name__)
 
 DEFAULT_CONFIG_PATH = os.path.join(
     platformdirs.user_config_dir(), 'geometamaker_profile.yml')
-DEFAULT_PROFILE = {
-    'contact': models.ContactSchema(),
-    'license': models.LicenseSchema()
-}
 
 
 # @dataclass()
@@ -33,18 +29,12 @@ class Config(object):
         self.config_path = config_path
         if not os.path.exists(self.config_path):
             if self.config_path == DEFAULT_CONFIG_PATH:
-                print('writing default profile')
-                with open(self.config_path, 'w') as file:
-                    file.write(yaml.dump(DEFAULT_PROFILE))
-
+                default_profile = models.Profile()
+                default_profile.write(self.config_path)
         try:
-            with open(self.config_path, 'r') as file:
-                yaml_string = file.read()
-            self.profile = yaml.safe_load(yaml_string)
+            self.profile = models.Profile.load(self.config_path)
         except:
-            self.profile = None
-
-        # profile: dict = DEFAULT_PROFILE
+            self.profile = models.Profile()
 
     # def save(self):
     #     with open(CONFIG_FILE, 'w') as file:

--- a/src/geometamaker/config.py
+++ b/src/geometamaker/config.py
@@ -1,0 +1,74 @@
+import logging
+import os
+import pprint
+from dataclasses import dataclass
+
+import fsspec
+import platformdirs
+import yaml
+
+
+LOGGER = logging.getLogger(__name__)
+
+DEFAULT_CONFIG_PATH = os.path.join(
+    platformdirs.user_config_dir(), 'geometamaker_profile.yml')
+DEFAULT_PROFILE = {
+    'contact': None,
+    'license': None
+}
+
+
+# @dataclass()
+class Config(object):
+
+    def __init__(self, config_path=DEFAULT_CONFIG_PATH):
+        """Load a configuration from a file.
+
+        Use a default user profile if none given. Create
+        that default profile if necessary.
+
+        """
+        self.config_path = config_path
+        if not os.path.exists(self.config_path):
+            if self.config_path == DEFAULT_CONFIG_PATH:
+                print('writing default profile')
+                with open(self.config_path, 'w') as file:
+                    file.write(yaml.dump(DEFAULT_PROFILE))
+
+        try:
+            with open(self.config_path, 'r') as file:
+                yaml_string = file.read()
+            self.profile = yaml.safe_load(yaml_string)
+        except:
+            self.profile = None
+
+        # profile: dict = DEFAULT_PROFILE
+
+    # def save(self):
+    #     with open(CONFIG_FILE, 'w') as file:
+    #         LOGGER.info(f'writing config to {CONFIG_FILE}')
+    #         file.write(yaml.dump(self.profile))
+
+    # def __str__(self):
+    #     return self.profile
+
+
+# def load_config(fname):
+#     print(fname)
+#     if not os.path.exists(fname):
+#         with open(fname, 'w') as file:
+#             file.write(yaml.dump(DEFAULT_PROFILE))
+
+#     with open(fname, 'r') as file:
+#         yaml_string = file.read()
+#     self.profile = yaml.safe_load(yaml_string)
+
+
+# def configure(self, contact=None, license=None, save=False):
+#     if contact:
+#         self.profile['contact'] = contact
+#     if license:
+#         self.profile['license'] = license
+
+#     if save:
+#         self.save()

--- a/src/geometamaker/config.py
+++ b/src/geometamaker/config.py
@@ -1,11 +1,7 @@
 import logging
 import os
-import pprint
-from dataclasses import dataclass
 
-import fsspec
 import platformdirs
-import yaml
 
 from . import models
 
@@ -16,51 +12,31 @@ DEFAULT_CONFIG_PATH = os.path.join(
     platformdirs.user_config_dir(), 'geometamaker_profile.yml')
 
 
-# @dataclass()
 class Config(object):
 
     def __init__(self, config_path=DEFAULT_CONFIG_PATH):
-        """Load a configuration from a file.
+        """Load a Profile from a config file.
 
         Use a default user profile if none given. Create
         that default profile if necessary.
 
         """
         self.config_path = config_path
-        if not os.path.exists(self.config_path):
-            if self.config_path == DEFAULT_CONFIG_PATH:
-                default_profile = models.Profile()
-                default_profile.write(self.config_path)
+
         try:
             self.profile = models.Profile.load(self.config_path)
-        except:
-            self.profile = models.Profile()
+        except FileNotFoundError as err:
+            LOGGER.debug(err)
+            pass
+        # TypeError from an invalid profile should not be caught
+        # TODO: any reason to init an empty profile?
+        #     self.profile = models.Profile()
 
-    # def save(self):
-    #     with open(CONFIG_FILE, 'w') as file:
-    #         LOGGER.info(f'writing config to {CONFIG_FILE}')
-    #         file.write(yaml.dump(self.profile))
+    def save(self, profile):
+        """Save a Profile as the default user profile.
 
-    # def __str__(self):
-    #     return self.profile
-
-
-# def load_config(fname):
-#     print(fname)
-#     if not os.path.exists(fname):
-#         with open(fname, 'w') as file:
-#             file.write(yaml.dump(DEFAULT_PROFILE))
-
-#     with open(fname, 'r') as file:
-#         yaml_string = file.read()
-#     self.profile = yaml.safe_load(yaml_string)
-
-
-# def configure(self, contact=None, license=None, save=False):
-#     if contact:
-#         self.profile['contact'] = contact
-#     if license:
-#         self.profile['license'] = license
-
-#     if save:
-#         self.save()
+        Args:
+            profile (geometamaker.models.Profile)
+        """
+        LOGGER.info(f'writing config to {self.config_path}')
+        profile.write(self.config_path)

--- a/src/geometamaker/config.py
+++ b/src/geometamaker/config.py
@@ -22,15 +22,19 @@ class Config(object):
 
         """
         self.config_path = config_path
+        self.profile = models.Profile()
 
         try:
             self.profile = models.Profile.load(self.config_path)
         except FileNotFoundError as err:
             LOGGER.debug(err)
             pass
-        # TypeError from an invalid profile should not be caught
-        # TODO: any reason to init an empty profile?
-        #     self.profile = models.Profile()
+        # an invalid profile should raise a TypeError
+        except TypeError as err:
+            LOGGER.warning(err)
+            LOGGER.warning(
+                f'{self.config_path} contains an inavlid profile. '
+                'It will be ignored. You may wish to delete() it.')
 
     def save(self, profile):
         """Save a Profile as the default user profile.
@@ -40,3 +44,7 @@ class Config(object):
         """
         LOGGER.info(f'writing config to {self.config_path}')
         profile.write(self.config_path)
+
+    def delete(self, config_path=DEFAULT_CONFIG_PATH):
+        LOGGER.info(f'removing {self.config_path}')
+        os.remove(config_path)

--- a/src/geometamaker/geometamaker.py
+++ b/src/geometamaker/geometamaker.py
@@ -256,8 +256,7 @@ def describe(source_dataset_path, profile=None):
     config = Config()
     user_profile = config.profile
     if profile is not None:
-        user_profile = models.Profile.replace(
-            user_profile, profile)
+        user_profile = user_profile.replace(profile)
 
     metadata_path = f'{source_dataset_path}.yml'
 
@@ -319,6 +318,6 @@ def describe(source_dataset_path, profile=None):
     # Or less common, ValueError if it exists but is incompatible
     except (FileNotFoundError, ValueError):
         resource = RESOURCE_MODELS[resource_type](**description)
-        resource.merge_profile(user_profile)
+        resource.replace(user_profile)
 
     return resource

--- a/src/geometamaker/geometamaker.py
+++ b/src/geometamaker/geometamaker.py
@@ -14,6 +14,21 @@ from . import models
 LOGGER = logging.getLogger(__name__)
 
 
+def configure(contact=None, license=None):
+
+    with open(CONFIG_FILE, 'r') as file:
+        yaml_string = file.read()
+    profiles = yaml.safe_load(yaml_string)
+
+    if contact:
+        profiles['contact'] = contact
+    if license:
+        profiles['license'] = license
+
+    with open(target_path, 'w') as file:
+        file.write(yaml.dump(PROFILES))
+
+
 def detect_file_type(filepath):
     """Detect the type of resource contained in the file.
 
@@ -236,7 +251,11 @@ def describe(source_dataset_path):
 
     # Common path: metadata file does not already exist
     # Or less common, ValueError if it exists but is incompatible
-    except (FileNotFoundError, ValueError) as err:
+    except (FileNotFoundError, ValueError):
         resource = RESOURCE_MODELS[resource_type](**description)
+        if CONTACT_PROFILE:
+            resource.set_contact(CONTACT_PROFILE)
+        if LICENSE_PROFILE:
+            resource.set_license(LICENSE_PROFILE)
 
     return resource

--- a/src/geometamaker/geometamaker.py
+++ b/src/geometamaker/geometamaker.py
@@ -253,9 +253,10 @@ def describe(source_dataset_path, profile=None):
         or RasterResource
 
     """
-    if profile is None:
-        CONFIG = Config()
-        profile = CONFIG.profile
+    CONFIG = Config()
+    user_profile = CONFIG.profile
+    if profile is not None:
+        
 
     metadata_path = f'{source_dataset_path}.yml'
 

--- a/src/geometamaker/geometamaker.py
+++ b/src/geometamaker/geometamaker.py
@@ -12,7 +12,7 @@ import pygeoprocessing
 from osgeo import gdal
 
 from . import models
-from .config import CONFIG
+from .config import Config
 
 
 LOGGER = logging.getLogger(__name__)
@@ -237,7 +237,7 @@ RESOURCE_MODELS = {
 }
 
 
-def describe(source_dataset_path):
+def describe(source_dataset_path, profile=None):
     """Create a metadata resource instance with properties of the dataset.
 
     Properties of the dataset are used to populate as many metadata
@@ -253,6 +253,10 @@ def describe(source_dataset_path):
         or RasterResource
 
     """
+    if profile is None:
+        CONFIG = Config()
+        profile = CONFIG.profile
+
     metadata_path = f'{source_dataset_path}.yml'
 
     # Despite naming, this does not open a file that must be closed
@@ -313,10 +317,9 @@ def describe(source_dataset_path):
     # Or less common, ValueError if it exists but is incompatible
     except (FileNotFoundError, ValueError):
         resource = RESOURCE_MODELS[resource_type](**description)
-        print(CONFIG)
-        if 'contact' in CONFIG and CONFIG['contact']:
-            resource.set_contact(CONFIG['contact'])
-        if 'license' in CONFIG and CONFIG['license']:
-            resource.set_license(CONFIG['license'])
+        if 'contact' in profile and profile['contact']:
+            resource.set_contact(**profile['contact'])
+        if 'license' in profile and profile['license']:
+            resource.set_license(**profile['license'])
 
     return resource

--- a/src/geometamaker/geometamaker.py
+++ b/src/geometamaker/geometamaker.py
@@ -253,11 +253,11 @@ def describe(source_dataset_path, profile=None):
         or RasterResource
 
     """
-    CONFIG = Config()
-    user_profile = CONFIG.profile
+    config = Config()
+    user_profile = config.profile
     if profile is not None:
-        for k, v in profile.items():
-            user_profile[k] = v
+        user_profile = models.Profile.replace(
+            user_profile, profile)
 
     metadata_path = f'{source_dataset_path}.yml'
 
@@ -319,9 +319,6 @@ def describe(source_dataset_path, profile=None):
     # Or less common, ValueError if it exists but is incompatible
     except (FileNotFoundError, ValueError):
         resource = RESOURCE_MODELS[resource_type](**description)
-        if 'contact' in user_profile and user_profile['contact']:
-            resource.set_contact(**user_profile['contact'])
-        if 'license' in user_profile and user_profile['license']:
-            resource.set_license(**user_profile['license'])
+        resource.merge_profile(user_profile)
 
     return resource

--- a/src/geometamaker/geometamaker.py
+++ b/src/geometamaker/geometamaker.py
@@ -318,6 +318,6 @@ def describe(source_dataset_path, profile=None):
     # Or less common, ValueError if it exists but is incompatible
     except (FileNotFoundError, ValueError):
         resource = RESOURCE_MODELS[resource_type](**description)
-        resource.replace(user_profile)
+        resource = resource.replace(user_profile)
 
     return resource

--- a/src/geometamaker/geometamaker.py
+++ b/src/geometamaker/geometamaker.py
@@ -4,29 +4,15 @@ import logging
 import frictionless
 import fsspec
 import numpy
-from osgeo import gdal
 import pygeoprocessing
 import yaml
+from osgeo import gdal
 
 from . import models
+from .config import CONFIG
 
 
 LOGGER = logging.getLogger(__name__)
-
-
-def configure(contact=None, license=None):
-
-    with open(CONFIG_FILE, 'r') as file:
-        yaml_string = file.read()
-    profiles = yaml.safe_load(yaml_string)
-
-    if contact:
-        profiles['contact'] = contact
-    if license:
-        profiles['license'] = license
-
-    with open(target_path, 'w') as file:
-        file.write(yaml.dump(PROFILES))
 
 
 def detect_file_type(filepath):
@@ -253,9 +239,10 @@ def describe(source_dataset_path):
     # Or less common, ValueError if it exists but is incompatible
     except (FileNotFoundError, ValueError):
         resource = RESOURCE_MODELS[resource_type](**description)
-        if CONTACT_PROFILE:
-            resource.set_contact(CONTACT_PROFILE)
-        if LICENSE_PROFILE:
-            resource.set_license(LICENSE_PROFILE)
+        print(CONFIG)
+        if 'contact' in CONFIG and CONFIG['contact']:
+            resource.set_contact(CONFIG['contact'])
+        if 'license' in CONFIG and CONFIG['license']:
+            resource.set_license(CONFIG['license'])
 
     return resource

--- a/src/geometamaker/geometamaker.py
+++ b/src/geometamaker/geometamaker.py
@@ -256,7 +256,8 @@ def describe(source_dataset_path, profile=None):
     CONFIG = Config()
     user_profile = CONFIG.profile
     if profile is not None:
-        
+        for k, v in profile.items():
+            user_profile[k] = v
 
     metadata_path = f'{source_dataset_path}.yml'
 
@@ -318,9 +319,9 @@ def describe(source_dataset_path, profile=None):
     # Or less common, ValueError if it exists but is incompatible
     except (FileNotFoundError, ValueError):
         resource = RESOURCE_MODELS[resource_type](**description)
-        if 'contact' in profile and profile['contact']:
-            resource.set_contact(**profile['contact'])
-        if 'license' in profile and profile['license']:
-            resource.set_license(**profile['license'])
+        if 'contact' in user_profile and user_profile['contact']:
+            resource.set_contact(**user_profile['contact'])
+        if 'license' in user_profile and user_profile['license']:
+            resource.set_license(**user_profile['license'])
 
     return resource

--- a/src/geometamaker/models.py
+++ b/src/geometamaker/models.py
@@ -592,6 +592,7 @@ class RasterResource(Resource):
         return self.schema.bands[band_number - 1]
 
 
+# TODO: Profile has a lot in common with Resource, consider some inheritance
 @dataclass
 class Profile():
     """Class for a metadata profile.

--- a/src/geometamaker/models.py
+++ b/src/geometamaker/models.py
@@ -211,6 +211,22 @@ class BaseMetadata:
         return self.license
 
     def replace(self, other):
+        """Replace attribute values with those from another instance.
+
+        Only attributes that exist in ``self`` will exist in the
+        returned instance. Only attribute values that are not None will be used
+        to replace existing attribute values in ``self``.
+
+        Args:
+            other (BaseMetadata)
+
+        Returns:
+            an instance of same type as ``self``
+
+        Raises:
+            TypeError if ``other`` is not an instance of BaseMetadata.
+
+        """
         if isinstance(other, BaseMetadata):
             return dataclasses.replace(
                 self, **{k: v for k, v in other.__dict__.items() if v is not None})

--- a/src/geometamaker/models.py
+++ b/src/geometamaker/models.py
@@ -132,7 +132,7 @@ class RasterSchema:
 
 
 @dataclass()
-class _Metadata:
+class BaseMetadata:
     """A class for the things shared by Resource and Profile."""
 
     contact: ContactSchema = None
@@ -211,14 +211,14 @@ class _Metadata:
         return self.license
 
     def replace(self, other):
-        if isinstance(other, _Metadata):
+        if isinstance(other, BaseMetadata):
             return dataclasses.replace(
                 self, **{k: v for k, v in other.__dict__.items() if v is not None})
-        raise NotImplementedError
+        raise TypeError(f'{other} must be an instance of BaseMetadata')
 
 
 @dataclass
-class Profile(_Metadata):
+class Profile(BaseMetadata):
     """Class for a metadata profile.
 
     A Profile can store metadata properties that are likely to apply
@@ -255,7 +255,7 @@ class Profile(_Metadata):
 
 
 @dataclass()
-class Resource(_Metadata):
+class Resource(BaseMetadata):
     """Base class for metadata for a resource.
 
     https://datapackage.org/standard/data-resource/

--- a/src/geometamaker/models.py
+++ b/src/geometamaker/models.py
@@ -214,7 +214,7 @@ class _Metadata:
         if isinstance(other, _Metadata):
             return dataclasses.replace(
                 self, **{k: v for k, v in other.__dict__.items() if v is not None})
-        return NotImplementedError
+        raise NotImplementedError
 
 
 @dataclass

--- a/src/geometamaker/models.py
+++ b/src/geometamaker/models.py
@@ -50,7 +50,7 @@ class ContactSchema:
 
 
 @dataclass
-class License:
+class LicenseSchema:
     """Class for storing license info."""
 
     # https://datapackage.org/profiles/2.0/dataresource.json
@@ -343,13 +343,13 @@ class Resource:
 
         # TODO: DataPackage/Resource allows for a list of licenses.
         # So far we only support one license per resource.
-        self.licenses = [License(**license_dict)]
+        self.licenses = [LicenseSchema(**license_dict)]
 
     def get_license(self):
         """Get ``license`` for the dataset.
 
         Returns:
-            models.License
+            models.LicenseSchema
 
         """
         # TODO: DataPackage/Resource allows for a list of licenses.
@@ -582,3 +582,11 @@ class RasterResource(Resource):
 
         """
         return self.schema.bands[band_number - 1]
+
+
+@dataclass
+class Profile():
+    """Class for a profile resource."""
+
+    contact: ContactSchema
+    licenses: list

--- a/tests/test_geometamaker.py
+++ b/tests/test_geometamaker.py
@@ -3,7 +3,7 @@ import os
 import shutil
 import tempfile
 import unittest
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 import numpy
 from osgeo import gdal
@@ -511,17 +511,6 @@ class GeometamakerTests(unittest.TestCase):
         resource = geometamaker.describe(filepath)
         self.assertEqual(resource.path, filepath)
 
-    def test_invalid_profile(self):
-        """Test invalid Profile raises TypeError."""
-        from geometamaker import models
-
-        with self.assertRaises(TypeError):
-            profile = models.Profile(contact={'foo_name': 'bob'})
-
-        profile = models.Profile()
-        with self.assertRaises(TypeError):
-            profile.set_contact(foo_name='bob')
-
 
 class ConfigurationTests(unittest.TestCase):
     """Tests for geometamaker configuration."""
@@ -555,7 +544,6 @@ class ConfigurationTests(unittest.TestCase):
 
         config = Config()
         config.save(profile)
-        # profile.write(geometamaker.config.DEFAULT_CONFIG_PATH)
 
         datasource_path = os.path.join(self.workspace_dir, 'raster.tif')
         create_raster(numpy.int16, datasource_path)

--- a/tests/test_geometamaker.py
+++ b/tests/test_geometamaker.py
@@ -529,7 +529,6 @@ class ConfigurationTests(unittest.TestCase):
         mock_user_config_dir.return_value = self.workspace_dir
         import geometamaker
         from geometamaker import models
-        from geometamaker.config import Config
 
         contact = {
             'individual_name': 'bob'
@@ -542,7 +541,7 @@ class ConfigurationTests(unittest.TestCase):
         profile.set_contact(**contact)
         profile.set_license(**license)
 
-        config = Config()
+        config = geometamaker.Config()
         config.save(profile)
 
         datasource_path = os.path.join(self.workspace_dir, 'raster.tif')
@@ -558,7 +557,6 @@ class ConfigurationTests(unittest.TestCase):
         mock_user_config_dir.return_value = self.workspace_dir
         import geometamaker
         from geometamaker import models
-        from geometamaker.config import Config
 
         contact = {
             'individual_name': 'bob'
@@ -566,7 +564,7 @@ class ConfigurationTests(unittest.TestCase):
 
         profile = models.Profile()
         profile.set_contact(**contact)
-        config = Config()
+        config = geometamaker.Config()
         config.save(profile)
 
         datasource_path = os.path.join(self.workspace_dir, 'raster.tif')
@@ -583,7 +581,6 @@ class ConfigurationTests(unittest.TestCase):
         mock_user_config_dir.return_value = self.workspace_dir
         import geometamaker
         from geometamaker import models
-        from geometamaker.config import Config
 
         contact = {
             'individual_name': 'bob'
@@ -594,7 +591,7 @@ class ConfigurationTests(unittest.TestCase):
         profile = models.Profile()
         profile.set_contact(**contact)
         profile.set_license(**license)
-        config = Config()
+        config = geometamaker.Config()
         config.save(profile)
 
         datasource_path = os.path.join(self.workspace_dir, 'raster.tif')
@@ -614,8 +611,8 @@ class ConfigurationTests(unittest.TestCase):
 
     def test_missing_config(self):
         """Test default profile is instantiated if config file is missing."""
-        from geometamaker.config import Config
-        config = Config('foo/path')
+        import geometamaker
+        config = geometamaker.Config('foo/path')
         self.assertEqual(config.profile.contact, None)
         self.assertEqual(config.profile.license, None)
 

--- a/tests/test_geometamaker.py
+++ b/tests/test_geometamaker.py
@@ -526,7 +526,6 @@ class ConfigurationTests(unittest.TestCase):
     @patch('geometamaker.config.platformdirs.user_config_dir')
     def test_user_configuration(self, mock_user_config_dir):
         """Test existing config populates resource."""
-        print(self.workspace_dir)
         mock_user_config_dir.return_value = self.workspace_dir
         import geometamaker
         import geometamaker.config
@@ -555,7 +554,6 @@ class ConfigurationTests(unittest.TestCase):
     @patch('geometamaker.config.platformdirs.user_config_dir')
     def test_runtime_configuration(self, mock_user_config_dir):
         """Test runtime config overrides user-level config."""
-        print(self.workspace_dir)
         mock_user_config_dir.return_value = self.workspace_dir
         import geometamaker
         import geometamaker.config
@@ -590,3 +588,27 @@ class ConfigurationTests(unittest.TestCase):
         # license was not part of profile passed at runtime,
         # so it should default to the user-config
         self.assertEqual(license['title'], resource.get_license().title)
+
+    @patch('geometamaker.config.platformdirs.user_config_dir')
+    def test_invalid_profile(self, mock_user_config_dir):
+        """Test runtime config overrides user-level config."""
+        mock_user_config_dir.return_value = self.workspace_dir
+        import geometamaker
+        import geometamaker.config
+
+        contact = {
+            'foo_name': 'bob'  # incorrect key
+        }
+        profile = {
+            'contact': contact,
+        }
+        with open(geometamaker.config.DEFAULT_CONFIG_PATH, 'w') as file:
+            file.write(yaml.dump(profile))
+
+        datasource_path = os.path.join(self.workspace_dir, 'raster.tif')
+        create_raster(numpy.int16, datasource_path)
+
+        resource = geometamaker.describe(
+            datasource_path, profile=profile)
+        self.assertEqual(profile['contact']['foo_name'],
+                         resource.get_contact().individual_name)

--- a/tests/test_geometamaker.py
+++ b/tests/test_geometamaker.py
@@ -528,8 +528,8 @@ class ConfigurationTests(unittest.TestCase):
         """Test existing config populates resource."""
         mock_user_config_dir.return_value = self.workspace_dir
         import geometamaker
-        import geometamaker.config
         from geometamaker import models
+        from geometamaker.config import Config
 
         contact = {
             'individual_name': 'bob'
@@ -541,7 +541,10 @@ class ConfigurationTests(unittest.TestCase):
         profile = models.Profile()
         profile.set_contact(**contact)
         profile.set_license(**license)
-        profile.write(geometamaker.config.DEFAULT_CONFIG_PATH)
+
+        config = Config()
+        config.save(profile)
+        # profile.write(geometamaker.config.DEFAULT_CONFIG_PATH)
 
         datasource_path = os.path.join(self.workspace_dir, 'raster.tif')
         create_raster(numpy.int16, datasource_path)
@@ -555,8 +558,8 @@ class ConfigurationTests(unittest.TestCase):
         """Test existing config populates resource."""
         mock_user_config_dir.return_value = self.workspace_dir
         import geometamaker
-        import geometamaker.config
         from geometamaker import models
+        from geometamaker.config import Config
 
         contact = {
             'individual_name': 'bob'
@@ -564,7 +567,9 @@ class ConfigurationTests(unittest.TestCase):
 
         profile = models.Profile()
         profile.set_contact(**contact)
-        profile.write(geometamaker.config.DEFAULT_CONFIG_PATH)
+        config = Config()
+        config.save(profile)
+        # profile.write(geometamaker.config.DEFAULT_CONFIG_PATH)
 
         datasource_path = os.path.join(self.workspace_dir, 'raster.tif')
         create_raster(numpy.int16, datasource_path)
@@ -579,8 +584,8 @@ class ConfigurationTests(unittest.TestCase):
         """Test runtime config overrides user-level config."""
         mock_user_config_dir.return_value = self.workspace_dir
         import geometamaker
-        import geometamaker.config
         from geometamaker import models
+        from geometamaker.config import Config
 
         contact = {
             'individual_name': 'bob'
@@ -591,7 +596,9 @@ class ConfigurationTests(unittest.TestCase):
         profile = models.Profile()
         profile.set_contact(**contact)
         profile.set_license(**license)
-        profile.write(geometamaker.config.DEFAULT_CONFIG_PATH)
+        config = Config()
+        config.save(profile)
+        # profile.write(geometamaker.config.DEFAULT_CONFIG_PATH)
 
         datasource_path = os.path.join(self.workspace_dir, 'raster.tif')
         create_raster(numpy.int16, datasource_path)
@@ -608,10 +615,15 @@ class ConfigurationTests(unittest.TestCase):
         # so it should default to the user-config
         self.assertEqual(license['title'], resource.get_license().title)
 
-    def test_invalid_profile(self, mock_user_config_dir):
-        """Test runtime config overrides user-level config."""
-        mock_user_config_dir.return_value = self.workspace_dir
-        import geometamaker
+    def test_missing_config(self):
+        """Test that default config is instantiated if file is missing."""
+        from geometamaker.config import Config
+        config = Config('foo/path')
+        self.assertEqual(config.profile.contact, None)
+        self.assertEqual(config.profile.license, None)
+
+    def test_invalid_profile(self):
+        """Test invalid Profile raises TypeError."""
         from geometamaker import models
 
         with self.assertRaises(TypeError):


### PR DESCRIPTION
This feature allows setting values for some metadata fields through the use of a "profile". Users might want to always use the same values for things like contact and license info. So a "profile" is a way to pass those values when describing a resource, without having to make separate calls to the resource's setters.

This PR also introduces a user-level config file that can be used to save a profile and re-use it by default. Values from this default profile will always be used when describing resources, unless they are overridden by a profile passed to `describe`.

Close #33 