### PR TITLE
Feature: list zipfile contents

### DIFF
--- a/src/geometamaker/geometamaker.py
+++ b/src/geometamaker/geometamaker.py
@@ -133,6 +133,13 @@ def describe_archive(source_dataset_path, scheme):
 
     """
     description = describe_file(source_dataset_path, scheme)
+    ZFS = fsspec.get_filesystem_class('zip')
+    zfs = ZFS(source_dataset_path)
+    file_list = []
+    for dirpath, _, files in zfs.walk(zfs.root_marker):
+        for f in files:
+            file_list.append(os.path.join(dirpath, f))
+    description['sources'] = file_list
     return description
 
 

--- a/src/geometamaker/geometamaker.py
+++ b/src/geometamaker/geometamaker.py
@@ -133,6 +133,10 @@ def describe_archive(source_dataset_path, scheme):
 
     """
     description = describe_file(source_dataset_path, scheme)
+    # innerpath is from frictionless and not useful because
+    # it does not include all the files contained in the zip
+    del description['innerpath']
+
     ZFS = fsspec.get_filesystem_class('zip')
     zfs = ZFS(source_dataset_path)
     file_list = []

--- a/src/geometamaker/models.py
+++ b/src/geometamaker/models.py
@@ -521,7 +521,6 @@ class ArchiveResource(Resource):
     """Class for metadata for an archive resource."""
 
     compression: str
-    innerpath: str
 
 
 @dataclass(kw_only=True)

--- a/tests/test_geometamaker.py
+++ b/tests/test_geometamaker.py
@@ -255,6 +255,18 @@ class GeometamakerTests(unittest.TestCase):
         self.assertEqual(band.nodata, raster_info['nodata'][band_idx])
         self.assertEqual(band.units, units)
 
+    def test_describe_zip(self):
+        """Test metadata for a zipfile."""
+        import zipfile
+        import geometamaker
+
+        zip_filepath = os.path.join(self.workspace_dir, 'data.zip')
+        zipf = zipfile.ZipFile(zip_filepath, "w", zipfile.ZIP_DEFLATED)
+        zipf.write('foo.txt')
+        zipf.write('bar.txt')
+        resource = geometamaker.describe(zip_filepath)
+        self.assertEqual(resource.sources, ['foo.txt', 'bar.txt'])
+
     def test_set_description(self):
         """Test set and get a description for a resource."""
 

--- a/tests/test_geometamaker.py
+++ b/tests/test_geometamaker.py
@@ -256,16 +256,27 @@ class GeometamakerTests(unittest.TestCase):
         self.assertEqual(band.units, units)
 
     def test_describe_zip(self):
-        """Test metadata for a zipfile."""
+        """Test metadata for a zipfile includes list of contents."""
         import zipfile
         import geometamaker
 
+        a_name = 'a.txt'
+        dir_name = 'subdir'
+        os.makedirs(os.path.join(self.workspace_dir, dir_name))
+        b_name = os.path.join(dir_name, 'b.txt')
+        a_path = os.path.join(self.workspace_dir, a_name)
+        b_path = os.path.join(self.workspace_dir, b_name)
+        with open(a_path, 'w') as file:
+            file.write('')
+        with open(b_path, 'w') as file:
+            file.write('')
+
         zip_filepath = os.path.join(self.workspace_dir, 'data.zip')
-        zipf = zipfile.ZipFile(zip_filepath, "w", zipfile.ZIP_DEFLATED)
-        zipf.write('foo.txt')
-        zipf.write('bar.txt')
+        with zipfile.ZipFile(zip_filepath, "w", zipfile.ZIP_DEFLATED) as zipf:
+            zipf.write(a_path, arcname=a_name)
+            zipf.write(b_path, arcname=b_name)
         resource = geometamaker.describe(zip_filepath)
-        self.assertEqual(resource.sources, ['foo.txt', 'bar.txt'])
+        self.assertEqual(resource.sources, [a_name, b_name])
 
     def test_set_description(self):
         """Test set and get a description for a resource."""


### PR DESCRIPTION
This feature uses `fsspec` to list the contents of a zip file without extracting it. `fsspec` is used in order for this feature to work the same on local and remote (`http`) files.

Fixes #40 

It's worth noting that we have #26 for adding support for other formats. `fsspec` supports these:
```python
fsspec.available_compressions()
[None, 'zip', 'bz2', 'gzip', 'lzma', 'xz']
```