### PR TITLE
Bump Pygeoprocessing requirement, and a couple other fixes

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,6 @@ GDAL
 frictionless
 numpy
 platformdirs
-pygeoprocessing>=2.4.3
+pygeoprocessing>=2.4.5
 pyyaml
 requests

--- a/src/geometamaker/config.py
+++ b/src/geometamaker/config.py
@@ -8,14 +8,13 @@ from . import models
 
 LOGGER = logging.getLogger(__name__)
 
-DEFAULT_CONFIG_PATH = os.path.join(
-    platformdirs.user_config_dir(), 'geometamaker_profile.yml')
+CONFIG_FILENAME = 'geometamaker_profile.yml'
 
 
 class Config(object):
     """Encapsulates user-settings such as a metadata Profile."""
 
-    def __init__(self, config_path=DEFAULT_CONFIG_PATH):
+    def __init__(self, config_path=None):
         """Load a Profile from a config file.
 
         Use a default user profile if none given.
@@ -24,7 +23,11 @@ class Config(object):
             config_path (str): path to a local yaml file
 
         """
-        self.config_path = config_path
+        if config_path is None:
+            self.config_path = os.path.join(
+                platformdirs.user_config_dir(), CONFIG_FILENAME)
+        else:
+            self.config_path = config_path
         self.profile = models.Profile()
 
         try:

--- a/src/geometamaker/geometamaker.py
+++ b/src/geometamaker/geometamaker.py
@@ -93,7 +93,7 @@ def _wkt_to_epsg_string(wkt_string):
         crs_string = (
             f"{srs.GetAttrValue('AUTHORITY', 0)}:"
             f"{srs.GetAttrValue('AUTHORITY', 1)}; "
-            f"Units:{srs.GetAttrValue('UNITS')}")
+            f"Units:{srs.GetAttrValue('UNIT', 0)}")
     except RuntimeError:
         LOGGER.warning(
             f'{wkt_string} cannot be interpreted as a coordinate reference system')

--- a/src/geometamaker/geometamaker.py
+++ b/src/geometamaker/geometamaker.py
@@ -395,6 +395,6 @@ def describe(source_dataset_path, profile=None):
     # Or less common, ValueError if it exists but is incompatible
     except (FileNotFoundError, ValueError):
         resource = RESOURCE_MODELS[resource_type](**description)
-        resource = resource.replace(user_profile)
 
+    resource = resource.replace(user_profile)
     return resource

--- a/src/geometamaker/models.py
+++ b/src/geometamaker/models.py
@@ -41,6 +41,7 @@ class SpatialSchema:
 
     bounding_box: BoundingBox
     crs: str
+    crs_units: str
 
 
 @dataclass

--- a/src/geometamaker/models.py
+++ b/src/geometamaker/models.py
@@ -248,6 +248,9 @@ class Profile(BaseMetadata):
 
     """
 
+    def __post_init__(self):
+        super().__post_init__()
+
     @classmethod
     def load(cls, filepath):
         """Load metadata document from a yaml file.
@@ -324,6 +327,7 @@ class Resource(BaseMetadata):
     url: str = ''
 
     def __post_init__(self):
+        super().__post_init__()
         self.metadata_path = f'{self.path}.yml'
         self.metadata_version: str = f'geometamaker.{geometamaker.__version__}'
         self.path = self.path.replace('\\', '/')

--- a/tests/test_geometamaker.py
+++ b/tests/test_geometamaker.py
@@ -500,6 +500,27 @@ class GeometamakerTests(unittest.TestCase):
         field2 = new_resource.get_field_description(field2_name)
         self.assertEqual(field2.type, 'String')
 
+    def test_preexisting_metadata_document_new_profile(self):
+        """Test ammending an existing Metadata document with a profile."""
+        import geometamaker
+
+        title = 'Title'
+        datasource_path = os.path.join(self.workspace_dir, 'raster.tif')
+        create_raster(numpy.int16, datasource_path)
+        resource = geometamaker.describe(datasource_path)
+        resource.set_title(title)
+        resource.set_contact(individual_name='alice')
+        resource.write()
+
+        profile = geometamaker.Profile()
+        profile.set_contact(individual_name='bob')
+        new_resource = geometamaker.describe(datasource_path, profile=profile)
+
+        self.assertEqual(
+            new_resource.get_title(), title)
+        self.assertEqual(
+            new_resource.contact.individual_name, 'bob')
+
     def test_preexisting_incompatible_doc(self):
         """Test when yaml file not created by geometamaker already exists."""
         import geometamaker

--- a/tests/test_geometamaker.py
+++ b/tests/test_geometamaker.py
@@ -219,7 +219,9 @@ class GeometamakerTests(unittest.TestCase):
         self.assertTrue(isinstance(
             resource.spatial, geometamaker.models.SpatialSchema))
         self.assertRegex(
-            resource.spatial.crs, r'EPSG:[0-9]*; Units:degree')
+            resource.spatial.crs, r'EPSG:[0-9]*')
+        self.assertEqual(
+            resource.spatial.crs_units, 'degree')
 
         resource.write()
         self.assertTrue(os.path.exists(f'{datasource_path}.yml'))

--- a/tests/test_geometamaker.py
+++ b/tests/test_geometamaker.py
@@ -213,11 +213,13 @@ class GeometamakerTests(unittest.TestCase):
         import geometamaker
 
         datasource_path = os.path.join(self.workspace_dir, 'raster.tif')
-        create_raster(numpy.int16, datasource_path)
+        create_raster(numpy.int16, datasource_path, projection_epsg=4326)
 
         resource = geometamaker.describe(datasource_path)
         self.assertTrue(isinstance(
             resource.spatial, geometamaker.models.SpatialSchema))
+        self.assertRegex(
+            resource.spatial.crs, r'EPSG:[0-9]*; Units:degree')
 
         resource.write()
         self.assertTrue(os.path.exists(f'{datasource_path}.yml'))

--- a/tests/test_geometamaker.py
+++ b/tests/test_geometamaker.py
@@ -561,7 +561,6 @@ class ConfigurationTests(unittest.TestCase):
         """Test existing config populates resource."""
         mock_user_config_dir.return_value = self.workspace_dir
         import geometamaker
-        from geometamaker import models
 
         contact = {
             'individual_name': 'bob'
@@ -570,7 +569,7 @@ class ConfigurationTests(unittest.TestCase):
             'title': 'CC-BY-4'
         }
 
-        profile = models.Profile()
+        profile = geometamaker.Profile()
         profile.set_contact(**contact)
         profile.set_license(**license)
 
@@ -655,7 +654,10 @@ class ConfigurationTests(unittest.TestCase):
         mock_user_config_dir.return_value = self.workspace_dir
         import geometamaker.config
 
-        with open(geometamaker.config.DEFAULT_CONFIG_PATH, 'w') as file:
+        config_path = os.path.join(
+            geometamaker.config.platformdirs.user_config_dir(),
+            geometamaker.config.CONFIG_FILENAME)
+        with open(config_path, 'w') as file:
             file.write(yaml.dump({'bad': 'data'}))
 
         config = geometamaker.config.Config()
@@ -668,10 +670,12 @@ class ConfigurationTests(unittest.TestCase):
         mock_user_config_dir.return_value = self.workspace_dir
         import geometamaker.config
 
-        with open(geometamaker.config.DEFAULT_CONFIG_PATH, 'w') as file:
+        config_path = os.path.join(
+            geometamaker.config.platformdirs.user_config_dir(),
+            geometamaker.config.CONFIG_FILENAME)
+        with open(config_path, 'w') as file:
             file.write(yaml.dump({'bad': 'data'}))
 
         config = geometamaker.config.Config()
         config.delete()
-        self.assertFalse(
-            os.path.exists(geometamaker.config.DEFAULT_CONFIG_PATH))
+        self.assertFalse(os.path.exists(config_path))


### PR DESCRIPTION
- The last PR that included `gdal.UseExceptions` needed to also require we use a version of pygeoprocessing that does the same, so that exceptions there are handled properly, such as in `get_gis_type`
- There was also a bug in the "units" representation of the CRS, which is fixed here.
- Another bug in the `Config` test mocking is fixed (see Slack thread for explanation)
- Fixes #50 
