### PR TITLE
Feature: respect newline characters in strings

### DIFF
--- a/src/geometamaker/geometamaker.py
+++ b/src/geometamaker/geometamaker.py
@@ -261,7 +261,7 @@ def describe_raster(source_dataset_path, scheme):
         b = i + 1
         bands.append(models.BandSchema(
             index=b,
-            gdal_type=info['datatype'],
+            gdal_type=gdal.GetDataTypeName(info['datatype']),
             numpy_type=numpy.dtype(info['numpy_type']).name,
             nodata=info['nodata'][i]))
     description['schema'] = models.RasterSchema(

--- a/src/geometamaker/models.py
+++ b/src/geometamaker/models.py
@@ -264,7 +264,7 @@ class Profile(BaseMetadata):
 
         """
         with open(target_path, 'w') as file:
-            file.write(utils._yaml_dump(dataclasses.asdict(self)))
+            file.write(utils.yaml_dump(dataclasses.asdict(self)))
 
 
 @dataclass()
@@ -443,7 +443,7 @@ class Resource(BaseMetadata):
                 provenance of the dataset
 
         """
-        self.lineage = utils.FoldedStr(f'{statement}')
+        self.lineage = statement
 
     def get_lineage(self):
         """Get the lineage statement of the dataset.
@@ -509,7 +509,7 @@ class Resource(BaseMetadata):
                 workspace, os.path.basename(self.metadata_path))
 
         with open(target_path, 'w') as file:
-            file.write(utils._yaml_dump(dataclasses.asdict(self)))
+            file.write(utils.yaml_dump(dataclasses.asdict(self)))
 
     def to_string(self):
         pass

--- a/src/geometamaker/models.py
+++ b/src/geometamaker/models.py
@@ -96,7 +96,7 @@ class BandSchema:
     """Class for metadata for a raster band."""
 
     index: int
-    gdal_type: int
+    gdal_type: str
     numpy_type: str
     nodata: int | float
     description: str = ''

--- a/src/geometamaker/models.py
+++ b/src/geometamaker/models.py
@@ -8,21 +8,10 @@ import fsspec
 import yaml
 
 import geometamaker
+from . import utils
 
 
 LOGGER = logging.getLogger(__name__)
-
-
-# https://stackoverflow.com/questions/13518819/avoid-references-in-pyyaml
-class _NoAliasDumper(yaml.SafeDumper):
-    """Keep the yaml human-readable by avoiding anchors and aliases."""
-
-    def ignore_aliases(self, data):
-        return True
-
-
-def _yaml_dump(data):
-    return yaml.dump(data, allow_unicode=True, Dumper=_NoAliasDumper)
 
 
 @dataclass(frozen=True)
@@ -272,7 +261,7 @@ class Profile(BaseMetadata):
 
         """
         with open(target_path, 'w') as file:
-            file.write(_yaml_dump(dataclasses.asdict(self)))
+            file.write(utils._yaml_dump(dataclasses.asdict(self)))
 
 
 @dataclass()
@@ -450,7 +439,7 @@ class Resource(BaseMetadata):
                 provenance of the dataset
 
         """
-        self.lineage = statement
+        self.lineage = utils.FoldedStr(f'{statement}')
 
     def get_lineage(self):
         """Get the lineage statement of the dataset.
@@ -516,7 +505,7 @@ class Resource(BaseMetadata):
                 workspace, os.path.basename(self.metadata_path))
 
         with open(target_path, 'w') as file:
-            file.write(_yaml_dump(dataclasses.asdict(self)))
+            file.write(utils._yaml_dump(dataclasses.asdict(self)))
 
     def to_string(self):
         pass

--- a/src/geometamaker/utils.py
+++ b/src/geometamaker/utils.py
@@ -1,0 +1,33 @@
+import yaml
+
+
+class FoldedStr(str):
+    pass
+
+
+def _change_style(style, representer):
+    def new_representer(dumper, data):
+        scalar = representer(dumper, data)
+        scalar.style = style
+        return scalar
+    return new_representer
+
+
+represent_folded_str = _change_style(
+    '>', yaml.representer.SafeRepresenter.represent_str)
+yaml.SafeDumper.add_representer(FoldedStr, represent_folded_str)
+
+
+# https://stackoverflow.com/questions/13518819/avoid-references-in-pyyaml
+class _NoAliasDumper(yaml.SafeDumper):
+    """Keep the yaml human-readable by avoiding anchors and aliases."""
+
+    def ignore_aliases(self, data):
+        return True
+
+
+def _yaml_dump(data):
+    return yaml.dump(
+        data,
+        allow_unicode=True,
+        Dumper=_NoAliasDumper)

--- a/src/geometamaker/utils.py
+++ b/src/geometamaker/utils.py
@@ -1,23 +1,24 @@
 import yaml
 
 
-def represent_str(dumper, data):
+def _represent_str(dumper, data):
     scalar = yaml.representer.SafeRepresenter.represent_str(dumper, data)
     if len(data.splitlines()) > 1:
         scalar.style = '|'  # literal style, newline chars will be new lines
     return scalar
 
 
-# Patch the default string representer so that it uses
-# a literal block style when the data contain newline characters
-yaml.SafeDumper.add_representer(str, represent_str)
+class _SafeDumper(yaml.SafeDumper):
 
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        # Patch the default string representer to use a literal block
+        # style when the data contain newline characters
+        self.add_representer(str, _represent_str)
 
-# https://stackoverflow.com/questions/13518819/avoid-references-in-pyyaml
-class _NoAliasDumper(yaml.SafeDumper):
-    """Keep the yaml human-readable by avoiding anchors and aliases."""
-
+    # https://stackoverflow.com/questions/13518819/avoid-references-in-pyyaml
     def ignore_aliases(self, data):
+        """Keep the yaml human-readable by avoiding anchors and aliases."""
         return True
 
 
@@ -25,4 +26,4 @@ def yaml_dump(data):
     return yaml.dump(
         data,
         allow_unicode=True,
-        Dumper=_NoAliasDumper)
+        Dumper=_SafeDumper)

--- a/src/geometamaker/utils.py
+++ b/src/geometamaker/utils.py
@@ -4,7 +4,7 @@ import yaml
 def represent_str(dumper, data):
     scalar = yaml.representer.SafeRepresenter.represent_str(dumper, data)
     if len(data.splitlines()) > 1:
-        scalar.style = '>'  # fold strings with newlines
+        scalar.style = '|'  # literal style, newline chars will be new lines
     return scalar
 
 

--- a/src/geometamaker/utils.py
+++ b/src/geometamaker/utils.py
@@ -1,21 +1,16 @@
 import yaml
 
 
-class FoldedStr(str):
-    pass
+def represent_str(dumper, data):
+    scalar = yaml.representer.SafeRepresenter.represent_str(dumper, data)
+    if len(data.splitlines()) > 1:
+        scalar.style = '>'  # fold strings with newlines
+    return scalar
 
 
-def _change_style(style, representer):
-    def new_representer(dumper, data):
-        scalar = representer(dumper, data)
-        scalar.style = style
-        return scalar
-    return new_representer
-
-
-represent_folded_str = _change_style(
-    '>', yaml.representer.SafeRepresenter.represent_str)
-yaml.SafeDumper.add_representer(FoldedStr, represent_folded_str)
+# Patch the default string representer so that it uses
+# a folded style when the data contains newline characters
+yaml.SafeDumper.add_representer(str, represent_str)
 
 
 # https://stackoverflow.com/questions/13518819/avoid-references-in-pyyaml
@@ -26,7 +21,7 @@ class _NoAliasDumper(yaml.SafeDumper):
         return True
 
 
-def _yaml_dump(data):
+def yaml_dump(data):
     return yaml.dump(
         data,
         allow_unicode=True,

--- a/src/geometamaker/utils.py
+++ b/src/geometamaker/utils.py
@@ -9,7 +9,7 @@ def represent_str(dumper, data):
 
 
 # Patch the default string representer so that it uses
-# a folded style when the data contains newline characters
+# a literal block style when the data contain newline characters
 yaml.SafeDumper.add_representer(str, represent_str)
 
 

--- a/tests/test_geometamaker.py
+++ b/tests/test_geometamaker.py
@@ -255,7 +255,8 @@ class GeometamakerTests(unittest.TestCase):
         band = resource.schema.bands[band_idx]
         self.assertEqual(band.title, title)
         self.assertEqual(band.description, description)
-        self.assertEqual(band.gdal_type, raster_info['datatype'])
+        self.assertEqual(
+            band.gdal_type, gdal.GetDataTypeName(raster_info['datatype']))
         self.assertEqual(band.numpy_type, numpy.dtype(numpy_type).name)
         self.assertEqual(band.nodata, raster_info['nodata'][band_idx])
         self.assertEqual(band.units, units)

--- a/tests/test_geometamaker.py
+++ b/tests/test_geometamaker.py
@@ -396,10 +396,27 @@ class GeometamakerTests(unittest.TestCase):
         import geometamaker
 
         resource = geometamaker.models.Resource()
-        statement = 'a lineage statment'
+        statement = 'a lineage statment\n is long and has\n many lines.'
 
         resource.set_lineage(statement)
         self.assertEqual(resource.get_lineage(), statement)
+
+    def test_lineage_roundtrip(self):
+        """Test writing and loading yaml with custom style."""
+        import geometamaker
+
+        datasource_path = os.path.join(self.workspace_dir, 'raster.tif')
+        numpy_type = numpy.int16
+        create_raster(numpy_type, datasource_path)
+
+        resource = geometamaker.describe(datasource_path)
+
+        statement = 'a lineage statment\n is long and has\n many lines.'
+        resource.set_lineage(statement)
+        resource.write()
+
+        new_resource = geometamaker.describe(datasource_path)
+        self.assertEqual(new_resource.get_lineage(), statement)
 
     def test_set_and_get_purpose(self):
         """Test set and get purpose of resource."""

--- a/tests/test_geometamaker.py
+++ b/tests/test_geometamaker.py
@@ -402,7 +402,7 @@ class GeometamakerTests(unittest.TestCase):
         self.assertEqual(resource.get_lineage(), statement)
 
     def test_lineage_roundtrip(self):
-        """Test writing and loading yaml with custom style."""
+        """Test writing and loading yaml with block indicator."""
         import geometamaker
 
         datasource_path = os.path.join(self.workspace_dir, 'raster.tif')


### PR DESCRIPTION
Instead of dumping a string with newline characters directly, we can add a yaml block indicator ( `|` ) to indicate that the dumper should treat newline chars as newlines. https://yaml-multiline.info/

The upshot is that we get this "literal" block,
```yaml
lineage: |-
  Created by natcap.invest.annual_water_yield.execute(
  {'biophysical_table_path': 'C:\\Users\\dmf\\projects\\invest\\data\\invest-sample-data\\Annual_Water_Yield\\biophysical_table_gura.csv',
   'depth_to_root_rest_layer_path': 'C:\\Users\\dmf\\projects\\invest\\data\\invest-sample-data\\Annual_Water_Yield\\depth_to_root_restricting_layer_gura.tif',
   'eto_path': 'C:\\Users\\dmf\\projects\\invest\\data\\invest-sample-data\\Annual_Water_Yield\\reference_ET_gura.tif',
   'lulc_path': 'C:\\Users\\dmf\\projects\\invest\\data\\invest-sample-data\\Annual_Water_Yield\\land_use_gura.tif',
   'pawc_path': 'C:\\Users\\dmf\\projects\\invest\\data\\invest-sample-data\\Annual_Water_Yield\\plant_available_water_fraction_gura.tif',
   'precipitation_path': 'C:\\Users\\dmf\\projects\\invest\\data\\invest-sample-data\\Annual_Water_Yield\\precipitation_gura.tif',
   'results_suffix': 'gura',
   'seasonality_constant': '5',
   'sub_watersheds_path': 'C:\\Users\\dmf\\projects\\invest\\data\\invest-sample-data\\Annual_Water_Yield\\subwatersheds_gura.shp',
   'watersheds_path': 'C:\\Users\\dmf\\projects\\invest\\data\\invest-sample-data\\Annual_Water_Yield\\watershed_gura.shp',
   'workspace_dir': 'runs/awy'})
  Version 3.14.1.post384+g36834555f.d20241029
```

instead of this double-quoted block,
```yaml
lineage: "Created by natcap.invest.annual_water_yield.execute(\n{'biophysical_table_path':\
  \ 'C:\\\\Users\\\\dmf\\\\projects\\\\invest\\\\data\\\\invest-sample-data\\\\Annual_Water_Yield\\\
  \\biophysical_table_gura.csv',\n 'depth_to_root_rest_layer_path': 'C:\\\\Users\\\
  \\dmf\\\\projects\\\\invest\\\\data\\\\invest-sample-data\\\\Annual_Water_Yield\\\
  \\depth_to_root_restricting_layer_gura.tif',\n 'eto_path': 'C:\\\\Users\\\\dmf\\\
  \\projects\\\\invest\\\\data\\\\invest-sample-data\\\\Annual_Water_Yield\\\\reference_ET_gura.tif',\n\
  \ 'lulc_path': 'C:\\\\Users\\\\dmf\\\\projects\\\\invest\\\\data\\\\invest-sample-data\\\
  \\Annual_Water_Yield\\\\land_use_gura.tif',\n 'pawc_path': 'C:\\\\Users\\\\dmf\\\
  \\projects\\\\invest\\\\data\\\\invest-sample-data\\\\Annual_Water_Yield\\\\plant_available_water_fraction_gura.tif',\n\
  \ 'precipitation_path': 'C:\\\\Users\\\\dmf\\\\projects\\\\invest\\\\data\\\\invest-sample-data\\\
  \\Annual_Water_Yield\\\\precipitation_gura.tif',\n 'results_suffix': 'gura',\n 'seasonality_constant':\
  \ '5',\n 'sub_watersheds_path': 'C:\\\\Users\\\\dmf\\\\projects\\\\invest\\\\data\\\
  \\invest-sample-data\\\\Annual_Water_Yield\\\\subwatersheds_gura.shp',\n 'watersheds_path':\
  \ 'C:\\\\Users\\\\dmf\\\\projects\\\\invest\\\\data\\\\invest-sample-data\\\\Annual_Water_Yield\\\
  \\watershed_gura.shp',\n 'workspace_dir': 'runs/awy'})\nVersion 3.14.1.post384+g36834555f.d20241029"
```
