### PR TITLE
Refactor to take advantage of Pydantic validation

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
         os: [ubuntu-latest, windows-latest, macos-latest]
 
     steps:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = "geometamaker"
 description = "metadata creation for geospatial data"
 readme = "README.md"
-requires-python = ">=3.10,<3.13"
+requires-python = ">=3.9,<3.13"
 license = {file = "LICENSE.txt"}
 maintainers = [
     {name = "Natural Capital Project Software Team"}
@@ -17,6 +17,7 @@ classifiers = [
     "Operating System :: Microsoft",
     "Operating System :: POSIX",
     "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,7 @@ GDAL
 frictionless
 numpy
 platformdirs
+Pydantic
 pygeoprocessing>=2.4.5
 pyyaml
 requests

--- a/src/geometamaker/config.py
+++ b/src/geometamaker/config.py
@@ -2,6 +2,7 @@ import logging
 import os
 
 import platformdirs
+from pydantic import ValidationError
 
 from . import models
 
@@ -35,8 +36,8 @@ class Config(object):
         except FileNotFoundError as err:
             LOGGER.debug('config file does not exist', exc_info=err)
             pass
-        # an invalid profile should raise a TypeError
-        except TypeError as err:
+        # an invalid profile should raise a ValidationError
+        except ValidationError as err:
             LOGGER.warning('', exc_info=err)
             LOGGER.warning(
                 f'{self.config_path} contains an inavlid profile. '

--- a/src/geometamaker/geometamaker.py
+++ b/src/geometamaker/geometamaker.py
@@ -1,4 +1,3 @@
-import dataclasses
 import functools
 import hashlib
 import logging
@@ -228,7 +227,7 @@ def describe_vector(source_dataset_path, scheme):
         fields.append(
             models.FieldSchema(name=fld.name, type=fld.GetTypeName()))
     vector = layer = None
-    description['schema'] = models.TableSchema(fields=fields)
+    description['data_model'] = models.TableSchema(fields=fields)
 
     info = pygeoprocessing.get_vector_info(source_dataset_path)
     bbox = models.BoundingBox(*info['bounding_box'])
@@ -264,7 +263,7 @@ def describe_raster(source_dataset_path, scheme):
             gdal_type=gdal.GetDataTypeName(info['datatype']),
             numpy_type=numpy.dtype(info['numpy_type']).name,
             nodata=info['nodata'][i]))
-    description['schema'] = models.RasterSchema(
+    description['data_model'] = models.RasterSchema(
         bands=bands,
         pixel_size=info['pixel_size'],
         raster_size=info['raster_size'])
@@ -293,7 +292,8 @@ def describe_table(source_dataset_path, scheme):
 
     """
     description = describe_file(source_dataset_path, scheme)
-    description['schema'] = models.TableSchema(**description['schema'])
+    description['data_model'] = models.TableSchema(**description['schema'])
+    del description['schema']  # we forbid extra args in our Pydantic models
     return description
 
 
@@ -354,42 +354,44 @@ def describe(source_dataset_path, profile=None):
     # Load existing metadata file
     try:
         existing_resource = RESOURCE_MODELS[resource_type].load(metadata_path)
-        if 'schema' in description:
-            if isinstance(description['schema'], models.RasterSchema):
-                # If existing band metadata still matches schema of the file
+        if 'data_model' in description:
+            if isinstance(description['data_model'], models.RasterSchema):
+                # If existing band metadata still matches data_model of the file
                 # carry over existing metadata because it could include
                 # human-defined properties.
                 new_bands = []
-                for band in description['schema'].bands:
+                for band in description['data_model'].bands:
                     try:
                         eband = existing_resource.get_band_description(band.index)
                         # TODO: rewrite this as __eq__ of BandSchema?
                         if (band.numpy_type, band.gdal_type, band.nodata) == (
                                 eband.numpy_type, eband.gdal_type, eband.nodata):
-                            band = dataclasses.replace(band, **eband.__dict__)
+                            updated_dict = band.model_dump() | eband.model_dump()
+                            band = models.BandSchema(**updated_dict)
                     except IndexError:
                         pass
                     new_bands.append(band)
-                description['schema'].bands = new_bands
-            if isinstance(description['schema'], models.TableSchema):
-                # If existing field metadata still matches schema of the file
+                description['data_model'].bands = new_bands
+            if isinstance(description['data_model'], models.TableSchema):
+                # If existing field metadata still matches data_model of the file
                 # carry over existing metadata because it could include
                 # human-defined properties.
                 new_fields = []
-                for field in description['schema'].fields:
+                for field in description['data_model'].fields:
                     try:
                         efield = existing_resource.get_field_description(
                             field.name)
                         # TODO: rewrite this as __eq__ of FieldSchema?
                         if field.type == efield.type:
-                            field = dataclasses.replace(field, **efield.__dict__)
+                            updated_dict = field.model_dump() | efield.model_dump()
+                            field = models.FieldSchema(**updated_dict)
                     except KeyError:
                         pass
                     new_fields.append(field)
-                description['schema'].fields = new_fields
+                description['data_model'].fields = new_fields
         # overwrite properties that are intrinsic to the dataset
-        resource = dataclasses.replace(
-            existing_resource, **description)
+        updated_dict = existing_resource.model_dump() | description
+        resource = RESOURCE_MODELS[resource_type](**updated_dict)
 
     # Common path: metadata file does not already exist
     # Or less common, ValueError if it exists but is incompatible

--- a/src/geometamaker/geometamaker.py
+++ b/src/geometamaker/geometamaker.py
@@ -357,8 +357,8 @@ def describe(source_dataset_path, profile=None):
         if 'schema' in description:
             if isinstance(description['schema'], models.RasterSchema):
                 # If existing band metadata still matches schema of the file
-                # carry over metadata from the existing file because it could
-                # include human-defined properties.
+                # carry over existing metadata because it could include
+                # human-defined properties.
                 new_bands = []
                 for band in description['schema'].bands:
                     try:
@@ -373,8 +373,8 @@ def describe(source_dataset_path, profile=None):
                 description['schema'].bands = new_bands
             if isinstance(description['schema'], models.TableSchema):
                 # If existing field metadata still matches schema of the file
-                # carry over metadata from the existing file because it could
-                # include human-defined properties.
+                # carry over existing metadata because it could include
+                # human-defined properties.
                 new_fields = []
                 for field in description['schema'].fields:
                     try:

--- a/src/geometamaker/geometamaker.py
+++ b/src/geometamaker/geometamaker.py
@@ -393,7 +393,7 @@ def describe(source_dataset_path, profile=None):
 
     # Common path: metadata file does not already exist
     # Or less common, ValueError if it exists but is incompatible
-    except (FileNotFoundError, ValueError):
+    except FileNotFoundError:
         resource = RESOURCE_MODELS[resource_type](**description)
 
     resource = resource.replace(user_profile)

--- a/src/geometamaker/models.py
+++ b/src/geometamaker/models.py
@@ -81,18 +81,6 @@ class TableSchema:
     primaryKey: list = dataclasses.field(default_factory=list)
     foreignKeys: list = dataclasses.field(default_factory=list)
 
-    # def __post_init__(self):
-    #     field_schemas = []
-    #     for field in self.fields:
-    #         # Allow init of the resource with a schema of type
-    #         # FieldSchema, or type dict. Mostly because dataclasses.replace
-    #         # calls init, but the base object will have already been initialized.
-    #         if isinstance(field, FieldSchema):
-    #             field_schemas.append(field)
-    #         else:
-    #             field_schemas.append(FieldSchema(**field))
-    #     self.fields = field_schemas
-
 
 @dataclass(config=ConfigDict(validate_assignment=True, extra='forbid'))
 class BandSchema:
@@ -115,22 +103,8 @@ class RasterSchema:
     pixel_size: list
     raster_size: list
 
-    # def __post_init__(self):
-    #     bands = []
-    #     for band in self.bands:
-    #         # When loading an existing document
-    #         # from serialized data we need to init a BandSchema for
-    #         # each band dict. But it's also okay to init a RasterSchema
-    #         # with bands as list of BandSchema.
-    #         if isinstance(band, BandSchema):
-    #             bands.append(band)
-    #         else:
-    #             bands.append(BandSchema(**band))
-    #     self.bands = bands
-
 
 @dataclass(config=ConfigDict(validate_assignment=True, extra='forbid'))
-# @dataclasses.dataclass
 class BaseMetadata:
     """A class for the things shared by Resource and Profile."""
 
@@ -139,16 +113,6 @@ class BaseMetadata:
     # Is there a better way?
     contact: ContactSchema | None = dataclasses.field(default_factory=ContactSchema)
     license: LicenseSchema | None = dataclasses.field(default_factory=LicenseSchema)
-
-    # TODO: pydantic coerces a dict to the correct type, no need to do this.
-    # def __post_init__(self):
-    #     # Allow init with an instance of the correct dataclass, or with a dict.
-    #     if self.contact is not None:
-    #         if not isinstance(self.contact, ContactSchema):
-    #             self.contact = ContactSchema(**self.contact)
-    #     if self.license is not None:
-    #         if not isinstance(self.license, LicenseSchema):
-    #             self.license = LicenseSchema(**self.license)
 
     def set_contact(self, organization=None, individual_name=None,
                     position_name=None, email=None):
@@ -250,9 +214,6 @@ class Profile(BaseMetadata):
     contact: ContactSchema | None = None
     license: LicenseSchema | None = None
 
-    # def __post_init__(self):
-    #     super().__post_init__()
-
     @classmethod
     def load(cls, filepath):
         """Load metadata document from a yaml file.
@@ -335,7 +296,6 @@ class Resource(BaseMetadata):
     url: str = ''
 
     def __post_init__(self):
-        # super().__post_init__()
         self.metadata_path = f'{self.path}.yml'
         self.metadata_version: str = f'geometamaker.{geometamaker.__version__}'
         self.path = self.path.replace('\\', '/')
@@ -561,17 +521,7 @@ class Resource(BaseMetadata):
 class TableResource(Resource):
     """Class for metadata for a table resource."""
 
-    # without post-init, schema ends up as a dict, or whatever is passed in.
     schema: TableSchema = dataclasses.field(default_factory=TableSchema)
-
-    # def __post_init__(self):
-    #     super().__post_init__()
-    #     # Allow init of the resource with a schema of type
-    #     # TableSchema, or type dict. Mostly because dataclasses.replace
-    #     # calls init, but the base object will have already been initialized.
-    #     if isinstance(self.schema, TableSchema):
-    #         return
-    #     self.schema = TableSchema(**self.schema)
 
     def _get_field(self, name):
         """Get an attribute by its name property.
@@ -656,15 +606,6 @@ class RasterResource(Resource):
 
     schema: RasterSchema
     spatial: SpatialSchema
-
-    # def __post_init__(self):
-    #     super().__post_init__()
-    #     # Allow init of the resource with a schema of type
-    #     # RasterSchema, or type dict. Mostly because dataclasses.replace
-    #     # calls init, but the base object will have already been initialized.
-    #     if isinstance(self.schema, RasterSchema):
-    #         return
-    #     self.schema = RasterSchema(**self.schema)
 
     def set_band_description(self, band_number, title=None,
                              description=None, units=None):

--- a/src/geometamaker/models.py
+++ b/src/geometamaker/models.py
@@ -127,7 +127,7 @@ class RasterSchema:
         self.bands = bands
 
 
-@dataclass(config=ConfigDict(validate_assignment=True))
+@dataclass(config=ConfigDict(validate_assignment=True, extra='forbid'))
 class BaseMetadata:
     """A class for the things shared by Resource and Profile."""
 

--- a/src/geometamaker/models.py
+++ b/src/geometamaker/models.py
@@ -131,9 +131,13 @@ class RasterSchema:
 class BaseMetadata:
     """A class for the things shared by Resource and Profile."""
 
-    contact: ContactSchema = None
-    license: LicenseSchema = None
+    # TODO: these default to None in order to facilitate the logic
+    # in ``replace`` where we only replace values that are not None.
+    # Is there a better way?
+    contact: ContactSchema | None = dataclasses.field(default_factory=ContactSchema)
+    license: LicenseSchema | None = dataclasses.field(default_factory=LicenseSchema)
 
+    # TODO: pydantic validation would not allow a dict anyway, or would it?
     def __post_init__(self):
         # Allow init with an instance of the correct dataclass, or with a dict.
         if self.contact is not None:
@@ -238,6 +242,11 @@ class Profile(BaseMetadata):
 
     """
 
+    # For a Profile, default these to None so that they do not replace
+    # values in a Resource
+    contact: ContactSchema | None = None
+    license: LicenseSchema | None = None
+
     def __post_init__(self):
         super().__post_init__()
 
@@ -310,12 +319,12 @@ class Resource(BaseMetadata):
     # These are not populated by geometamaker.describe(),
     # and should have setters & getters
     citation: str = ''
-    contact: ContactSchema = dataclasses.field(default_factory=ContactSchema)
+    # contact: ContactSchema = dataclasses.field(default_factory=ContactSchema)
     description: str = ''
     doi: str = ''
     edition: str = ''
     keywords: list = dataclasses.field(default_factory=list)
-    license: LicenseSchema = dataclasses.field(default_factory=LicenseSchema)
+    # license: LicenseSchema = dataclasses.field(default_factory=LicenseSchema)
     lineage: str = ''
     placenames: list = dataclasses.field(default_factory=list)
     purpose: str = ''

--- a/src/geometamaker/models.py
+++ b/src/geometamaker/models.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 import dataclasses
-from dataclasses import dataclass
+from pydantic.dataclasses import dataclass
 import logging
 import os
 

--- a/src/geometamaker/models.py
+++ b/src/geometamaker/models.py
@@ -1,11 +1,12 @@
 from __future__ import annotations
 import dataclasses
-from pydantic.dataclasses import dataclass
 import logging
 import os
 
 import fsspec
 import yaml
+from pydantic import ConfigDict
+from pydantic.dataclasses import dataclass
 
 import geometamaker
 from . import utils
@@ -126,7 +127,7 @@ class RasterSchema:
         self.bands = bands
 
 
-@dataclass()
+@dataclass(config=ConfigDict(validate_assignment=True))
 class BaseMetadata:
     """A class for the things shared by Resource and Profile."""
 
@@ -283,7 +284,12 @@ class Resource(BaseMetadata):
     """
 
     # A version string we can use to identify geometamaker compliant documents
-    metadata_version: str = dataclasses.field(init=False)
+    # TODO: Don't want a default value, but can't mix with defaults
+    # so set init=False
+    # metadata_version: str = dataclasses.field(init=False)
+    metadata_version: str = ''
+    # TODO: don't want to include this in doc, but need it as an attribute
+    metadata_path: str = ''
 
     # These are populated geometamaker.describe()
     bytes: int = 0
@@ -345,9 +351,8 @@ class Resource(BaseMetadata):
         if 'metadata_version' not in yaml_dict \
                 or not yaml_dict['metadata_version'].startswith('geometamaker'):
             message = (f'{filepath} exists but is not compatible with '
-                       f'geometamaker. It will be overwritten if write() is '
-                       f'called for this resource.')
-            LOGGER.warning(message)
+                       f'geometamaker.')
+            # LOGGER.warning(message)
             raise ValueError(message)
         # delete this property so that geometamaker can initialize it itself
         # with the current version info.

--- a/src/geometamaker/models.py
+++ b/src/geometamaker/models.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 import logging
 import os
-from typing import List
+from typing import List, Union
 
 import fsspec
 import yaml
@@ -88,7 +88,7 @@ class BandSchema(Parent):
     index: int
     gdal_type: str
     numpy_type: str
-    nodata: int | float
+    nodata: Union[int, float]
     description: str = ''
     title: str = ''
     units: str = ''
@@ -108,8 +108,8 @@ class BaseMetadata(Parent):
     # TODO: these default to None in order to facilitate the logic
     # in ``replace`` where we only replace values that are not None.
     # Is there a better way?
-    contact: ContactSchema | None = Field(default_factory=ContactSchema)
-    license: LicenseSchema | None = Field(default_factory=LicenseSchema)
+    contact: Union[ContactSchema, None] = Field(default_factory=ContactSchema)
+    license: Union[LicenseSchema, None] = Field(default_factory=LicenseSchema)
 
     def set_contact(self, organization=None, individual_name=None,
                     position_name=None, email=None):
@@ -208,8 +208,8 @@ class Profile(BaseMetadata):
 
     # For a Profile, default these to None so that they do not replace
     # values in a Resource
-    contact: ContactSchema | None = None
-    license: LicenseSchema | None = None
+    contact: Union[ContactSchema, None] = None
+    license: Union[LicenseSchema, None] = None
 
     @classmethod
     def load(cls, filepath):

--- a/src/geometamaker/models.py
+++ b/src/geometamaker/models.py
@@ -16,12 +16,14 @@ LOGGER = logging.getLogger(__name__)
 
 
 class Parent(BaseModel):
+    """Parent class on which to configure validation."""
 
     model_config = ConfigDict(validate_assignment=True, extra='forbid')
 
-# TODO: dataclass allows positional args, BaseModel does not.
-# positional args are convenient for BoundingBox, but not critical
-# to keep this way.
+
+# dataclass allows positional args, BaseModel does not.
+# positional args are convenient for initializing BoundingBox,
+# but we could switch to BaseModel for consistency.
 @dataclass(frozen=True)
 class BoundingBox:
     """Class for a spatial bounding box."""
@@ -105,9 +107,8 @@ class RasterSchema(Parent):
 class BaseMetadata(Parent):
     """A class for the things shared by Resource and Profile."""
 
-    # TODO: these default to None in order to facilitate the logic
+    # These default to None in order to facilitate the logic
     # in ``replace`` where we only replace values that are not None.
-    # Is there a better way?
     contact: Union[ContactSchema, None] = Field(default_factory=ContactSchema)
     license: Union[LicenseSchema, None] = Field(default_factory=LicenseSchema)
 
@@ -253,9 +254,6 @@ class Resource(BaseMetadata):
     """
 
     # A version string we can use to identify geometamaker compliant documents
-    # TODO: Don't want a default value, but can't mix with defaults
-    # so set init=False
-    # metadata_version: str = Field(init=False)
     metadata_version: str = ''
     # TODO: don't want to include this in doc, but need it as an attribute
     metadata_path: str = ''
@@ -279,12 +277,10 @@ class Resource(BaseMetadata):
     # These are not populated by geometamaker.describe(),
     # and should have setters & getters
     citation: str = ''
-    # contact: ContactSchema = Field(default_factory=ContactSchema)
     description: str = ''
     doi: str = ''
     edition: str = ''
     keywords: list = Field(default_factory=list)
-    # license: LicenseSchema = Field(default_factory=LicenseSchema)
     lineage: str = ''
     placenames: list = Field(default_factory=list)
     purpose: str = ''
@@ -320,7 +316,6 @@ class Resource(BaseMetadata):
                 or not yaml_dict['metadata_version'].startswith('geometamaker'):
             message = (f'{filepath} exists but is not compatible with '
                        f'geometamaker.')
-            # LOGGER.warning(message)
             raise ValueError(message)
         # delete this property so that geometamaker can initialize it itself
         # with the current version info.

--- a/tests/test_geometamaker.py
+++ b/tests/test_geometamaker.py
@@ -605,11 +605,14 @@ class ValidationTests(unittest.TestCase):
         """Override tearDown function to remove temporary directory."""
         shutil.rmtree(self.workspace_dir)
 
-    def test_init_raises_ValidationError(self):
+    def test_init_resource_raises_ValidationError(self):
         import geometamaker
 
         with self.assertRaises(ValidationError):
             _ = geometamaker.models.Resource(title=0)
+
+        with self.assertRaises(ValidationError):
+            _ = geometamaker.models.Profile(license='foo')
 
     def test_assignment_raises_ValidationError(self):
         import geometamaker
@@ -617,6 +620,10 @@ class ValidationTests(unittest.TestCase):
         resource = geometamaker.models.Resource()
         with self.assertRaises(ValidationError):
             resource.title = 0
+
+        profile = geometamaker.models.Profile()
+        with self.assertRaises(ValidationError):
+            profile.license = 'foo'
 
 
 class ConfigurationTests(unittest.TestCase):

--- a/tests/test_geometamaker.py
+++ b/tests/test_geometamaker.py
@@ -131,7 +131,7 @@ class GeometamakerTests(unittest.TestCase):
 
         resource = geometamaker.describe(datasource_path)
         self.assertEqual(
-            len(resource.schema.fields),
+            len(resource.data_model.fields),
             len(field_names))
         self.assertEqual(resource.get_field_description('Strings').type, 'string')
         self.assertEqual(resource.get_field_description('Ints').type, 'integer')
@@ -149,7 +149,7 @@ class GeometamakerTests(unittest.TestCase):
             field_names[1],
             units=units)
 
-        field = [field for field in resource.schema.fields
+        field = [field for field in resource.data_model.fields
                  if field.name == field_names[1]][0]
         self.assertEqual(field.title, title)
         self.assertEqual(field.description, description)
@@ -171,7 +171,7 @@ class GeometamakerTests(unittest.TestCase):
 
         resource.write()
         self.assertEqual(
-            len(resource.schema.fields),
+            len(resource.data_model.fields),
             len(field_names))
         self.assertEqual(resource.get_field_description('Strings').type, 'string')
         self.assertEqual(resource.get_field_description('Ints').type, 'integer')
@@ -208,7 +208,7 @@ class GeometamakerTests(unittest.TestCase):
         create_vector(datasource_path, None)
 
         resource = geometamaker.describe(datasource_path)
-        self.assertEqual(len(resource.schema.fields), 0)
+        self.assertEqual(len(resource.data_model.fields), 0)
 
     def test_describe_raster(self):
         """Test metadata for basic raster."""
@@ -252,9 +252,9 @@ class GeometamakerTests(unittest.TestCase):
 
         raster_info = pygeoprocessing.get_raster_info(datasource_path)
         self.assertEqual(
-            len(resource.schema.bands), raster_info['n_bands'])
+            len(resource.data_model.bands), raster_info['n_bands'])
         band_idx = band_number - 1
-        band = resource.schema.bands[band_idx]
+        band = resource.data_model.bands[band_idx]
         self.assertEqual(band.title, title)
         self.assertEqual(band.description, description)
         self.assertEqual(

--- a/tests/test_geometamaker.py
+++ b/tests/test_geometamaker.py
@@ -625,6 +625,12 @@ class ValidationTests(unittest.TestCase):
         with self.assertRaises(ValidationError):
             profile.license = 'foo'
 
+    def test_extra_fields_raises_ValidationError(self):
+        import geometamaker
+
+        with self.assertRaises(ValidationError):
+            _ = geometamaker.models.Resource(foo=0)
+
 
 class ConfigurationTests(unittest.TestCase):
     """Tests for geometamaker configuration."""


### PR DESCRIPTION
This PR refactors the data models to inherit from Pydantic's `BaseModel`.

Pydantic is useful for type-checking (aka "validation"). And using `BaseModel` instead of `pydantic.dataclasses` neatly works around the problem described in #54 

We're now validating metadata documents on `Resource.__init__`, in other words, when a new dataset is described or an existing document is loaded from a file. And we also validate fields on assignment.

One change to the metadata specification:
`schema` is a reserved attribute by Pydantic. So I renamed our `schema` attribute to `data_model`, and added a clause to do that migration when an existing yaml doc is loaded, if needed. We should do some future planning around metadata schema versioning.

Fixes #54 
Fixes #29 