### PR TITLE
Feature: Command-line interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,6 @@ to add these values manually by editing the
 ### Creating metadata for a batch of files:
 
 #### Python
-
 ```python
 import os
 
@@ -70,6 +69,41 @@ geometamaker.describe_dir(data_dir, recursive=True)
 #### CLI
 ```
 geometamaker describe -r data/invest-sample-data
+```
+
+### Validating a metadata document:
+If you have manually edited a `.yml` metadata document,
+it is a good idea to validate it for correct syntax, properties, and types.
+
+##### Python
+```python
+import geometamaker
+
+document_path = 'data/watershed_gura.shp.yml'
+error = geometamaker.validate(document_path)
+print(error)
+```
+
+##### CLI
+```
+geometamaker validate data/watershed_gura.shp.yml
+```
+
+### Validating all metadata documents in a directory
+
+##### Python
+```python
+import geometamaker
+
+directory_path = 'data/'
+yaml_files, messages = geometamaker.validate_dir(data)
+for filepath, msg in zip(yaml_files, messages):
+    print(f'{filepath}: {msg}')
+```
+
+##### CLI
+```
+geometamaker validate data
 ```
 
 ### Configuring default values for metadata properties:
@@ -133,7 +167,7 @@ resource = geometamaker.describe(data_path)
 geometamaker config
 ```
 This will prompt the user to enter their profile information.  
-Also see `geometamaker config --help`
+Also see `geometamaker config --help`.
 
 ### For a complete list of methods:
 https://geometamaker.readthedocs.io/en/latest/api/geometamaker.html

--- a/README.md
+++ b/README.md
@@ -6,9 +6,15 @@ Supported datatypes include:
 * compressed formats supported by `frictionless`
 
 
-See `requirements.txt` for dependencies
+See `requirements.txt` for dependencies.
+
+This library comes with a command-line interface (CLI) called `geometamaker`.
+Many of the examples below show how to use the Python interface, and then
+how to do the same thing, if possible, using the CLI.
 
 ### Creating & adding metadata to file:
+
+##### Python
 
 ```python
 import geometamaker
@@ -38,22 +44,32 @@ resource.set_band_description(
 resource.write()
 ```
 
+##### CLI
+```
+geometamaker describe data/watershed_gura.shp
+```
+The CLI does not provide options for setting metadata properties such as 
+keywords, field or band descriptions, or other properties that require 
+user-input. If you create a metadata document with the CLI, you may wish 
+to add these values manually by editing the 
+`watershed_gura.shp.yml` file in a text editor.
+
 ### Creating metadata for a batch of files:
+
+#### Python
+
 ```python
 import os
 
 import geometamaker
 
 data_dir = 'C:/Users/dmf/projects/invest/data/invest-sample-data'
-for path, dirs, files in os.walk(data_dir):
-    for file in files:
-        filepath = os.path.join(path, file)
-        print(filepath)
-        try:
-            resource = geometamaker.describe(filepath)
-        except ValueError as err:
-            print(err)
-        resource.write()
+geometamaker.describe_dir(data_dir, recursive=True)
+```
+
+#### CLI
+```
+geometamaker describe -r data/invest-sample-data
 ```
 
 ### Configuring default values for metadata properties:
@@ -90,6 +106,8 @@ resource = geometamaker.describe(data_path, profile=profile)
 ```
 
 #### Store a Profile in user-configuration
+
+##### Python
 ```python
 import os
 
@@ -110,6 +128,12 @@ data_path = 'data/watershed_gura.shp'
 resource = geometamaker.describe(data_path)
 ```
 
+##### CLI
+```
+geometamaker config
+```
+This will prompt the user to enter their profile information.  
+Also see `geometamaker config --help`
 
 ### For a complete list of methods:
 https://geometamaker.readthedocs.io/en/latest/api/geometamaker.html

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ classifiers = [
 dynamic = ["version", "dependencies", "optional-dependencies"]
 
 [project.scripts]
-geometamaker = "geometamaker.geometamaker.cli:main"
+geometamaker = "geometamaker.cli:cli"
 
 [build-system]
 requires = ["setuptools >= 40.6.0", "wheel", "setuptools_scm"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,9 @@ classifiers = [
 # using the corresponding setup args `install_requires` and `extras_require`
 dynamic = ["version", "dependencies", "optional-dependencies"]
 
+[project.scripts]
+geometamaker = "geometamaker.geometamaker.cli:main"
+
 [build-system]
 requires = ["setuptools >= 40.6.0", "wheel", "setuptools_scm"]
 build-backend = "setuptools.build_meta"

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@
 # This file records the packages and requirements needed in order for
 # the library to work as expected. And to run tests.
 aiohttp
+click
 fsspec
 GDAL
 frictionless

--- a/src/geometamaker/__init__.py
+++ b/src/geometamaker/__init__.py
@@ -2,10 +2,11 @@ import importlib.metadata
 
 from .geometamaker import describe
 from .geometamaker import validate
+from .geometamaker import validate_dir
 from .config import Config
 from .models import Profile
 
 
 __version__ = importlib.metadata.version('geometamaker')
 
-__all__ = ('describe', 'validate', 'Config', 'Profile')
+__all__ = ('describe', 'validate', 'validate_dir', 'Config', 'Profile')

--- a/src/geometamaker/__init__.py
+++ b/src/geometamaker/__init__.py
@@ -1,6 +1,7 @@
 import importlib.metadata
 
 from .geometamaker import describe
+from .geometamaker import describe_dir
 from .geometamaker import validate
 from .geometamaker import validate_dir
 from .config import Config

--- a/src/geometamaker/__init__.py
+++ b/src/geometamaker/__init__.py
@@ -1,10 +1,11 @@
 import importlib.metadata
 
 from .geometamaker import describe
+from .geometamaker import validate
 from .config import Config
 from .models import Profile
 
 
 __version__ = importlib.metadata.version('geometamaker')
 
-__all__ = ('describe', 'Config', 'Profile')
+__all__ = ('describe', 'validate', 'Config', 'Profile')

--- a/src/geometamaker/__init__.py
+++ b/src/geometamaker/__init__.py
@@ -9,4 +9,4 @@ from .models import Profile
 
 __version__ = importlib.metadata.version('geometamaker')
 
-__all__ = ('describe', 'validate', 'validate_dir', 'Config', 'Profile')
+__all__ = ('describe', 'describe_dir', 'validate', 'validate_dir', 'Config', 'Profile')

--- a/src/geometamaker/cli.py
+++ b/src/geometamaker/cli.py
@@ -14,19 +14,6 @@ formatter = logging.Formatter(
     fmt='%(asctime)s %(name)-18s %(levelname)-8s %(message)s',
     datefmt='%m/%d/%Y %H:%M:%S ')
 handler.setFormatter(formatter)
-handler.setLevel(logging.INFO)  # TODO: take user input
-root_logger.addHandler(handler)
-
-
-def echo_validation_error(error, filepath):
-    summary = u'\u2715' + f' {filepath}: {error.error_count()} validation errors'
-    click.secho(summary, fg='bright_red')
-    for e in error.errors():
-        location = ', '.join(e['loc'])
-        msg_string = (f"    {e['msg']}. [input_value={e['input']}, "
-                      f"input_type={type(e['input']).__name__}]")
-        click.secho(location, bold=True)
-        click.secho(msg_string)
 
 
 @click.command(
@@ -52,6 +39,17 @@ def describe(filepath, recursive, no_write):
                 resource.model_dump(exclude=['metadata_path'])))
         else:
             resource.write()
+
+
+def echo_validation_error(error, filepath):
+    summary = u'\u2715' + f' {filepath}: {error.error_count()} validation errors'
+    click.secho(summary, fg='bright_red')
+    for e in error.errors():
+        location = ', '.join(e['loc'])
+        msg_string = (f"    {e['msg']}. [input_value={e['input']}, "
+                      f"input_type={type(e['input']).__name__}]")
+        click.secho(location, bold=True)
+        click.secho(msg_string)
 
 
 @click.command(
@@ -141,8 +139,14 @@ def config(individual_name, email, organization, position_name,
 
 
 @click.group()
-def cli():
-    pass
+@click.option('-v', 'verbosity', count=True, default=2, required=False,
+              help='''Override the default verbosity of logging. Use "-vvv" for
+              debug-level logging. Omit this flag for default,
+              info-level logging.''')
+def cli(verbosity):
+    log_level = logging.ERROR - verbosity*10
+    handler.setLevel(log_level)
+    root_logger.addHandler(handler)
 
 
 cli.add_command(describe)

--- a/src/geometamaker/cli.py
+++ b/src/geometamaker/cli.py
@@ -96,9 +96,8 @@ def delete_config(ctx, param, value):
 @click.option('--license_path', prompt=True, default='')
 @click.option('-p', '--print', is_flag=True, is_eager=True,
               callback=print_config, expose_value=False)
-@click.confirmation_option(
-    '--delete', is_flag=True, is_eager=True,
-    callback=delete_config, expose_value=False)
+@click.option('--delete', is_flag=True, is_eager=True,
+              callback=delete_config, expose_value=False)
 def config(individual_name, email, organization, position_name,
            license_path, license_title):
     contact = geometamaker.models.ContactSchema()

--- a/src/geometamaker/cli.py
+++ b/src/geometamaker/cli.py
@@ -30,6 +30,9 @@ handler.setFormatter(formatter)
                    'This option is ignored if `filepath` is a directory')
 def describe(filepath, recursive, no_write):
     if os.path.isdir(filepath):
+        if no_write:
+            click.echo('the -nw, or --no-write, flag is ignored when '
+                       'describing all files in a directory.')
         geometamaker.describe_dir(
             filepath, recursive=recursive)
     else:

--- a/src/geometamaker/cli.py
+++ b/src/geometamaker/cli.py
@@ -7,13 +7,13 @@ from pydantic import ValidationError
 
 import geometamaker
 
-root_logger = logging.getLogger()
-root_logger.setLevel(logging.DEBUG)
-handler = logging.StreamHandler(sys.stdout)
-formatter = logging.Formatter(
+ROOT_LOGGER = logging.getLogger()
+ROOT_LOGGER.setLevel(logging.DEBUG)
+HANDLER = logging.StreamHandler(sys.stdout)
+FORMATTER = logging.Formatter(
     fmt='%(asctime)s %(name)-18s %(levelname)-8s %(message)s',
     datefmt='%m/%d/%Y %H:%M:%S ')
-handler.setFormatter(formatter)
+HANDLER.setFormatter(FORMATTER)
 
 
 @click.command(
@@ -149,8 +149,8 @@ def config(individual_name, email, organization, position_name,
 @click.version_option(message="%(version)s")
 def cli(verbosity):
     log_level = logging.ERROR - verbosity*10
-    handler.setLevel(log_level)
-    root_logger.addHandler(handler)
+    HANDLER.setLevel(log_level)
+    ROOT_LOGGER.addHandler(HANDLER)
 
 
 cli.add_command(describe)

--- a/src/geometamaker/cli.py
+++ b/src/geometamaker/cli.py
@@ -1,9 +1,10 @@
 import argparse
 import logging
-import pprint
+import os
 import sys
 
 import geometamaker
+
 
 def main(user_args=None):
     parser = argparse.ArgumentParser(
@@ -22,7 +23,10 @@ def main(user_args=None):
         'validate', help='validate a metadata document')
     validate_subparser.add_argument(
         'filepath',
-        help=('path to a metadata document to validate'))
+        help=('path to a metadata document, or directory containing documents, to validate'))
+    validate_subparser.add_argument(
+        '-r', '--recursive', action='store_true', default=False,
+        help='recurse through subdirectories in search of metadata documents.')
 
     args = parser.parse_args(user_args)
 
@@ -40,9 +44,15 @@ def main(user_args=None):
         parser.exit()
 
     if args.subcommand == 'validate':
-        validation_message = geometamaker.validate(args.filepath)
-        if validation_message:
-            sys.stdout.write(validation_message)
+        if os.path.isdir(args.filepath):
+            file_list, message_list = geometamaker.validate_dir(
+                args.filepath, recursive=args.recursive)
+            for filepath, msg in zip(file_list, message_list):
+                sys.stdout.write(f'{filepath}: {msg}\n')
+        else:
+            validation_message = geometamaker.validate(args.filepath)
+            if validation_message:
+                sys.stdout.write(validation_message)
         parser.exit()
 
 

--- a/src/geometamaker/cli.py
+++ b/src/geometamaker/cli.py
@@ -115,7 +115,7 @@ def delete_config(ctx, param, value):
 @click.option('--position-name', prompt=True, default='')
 @click.option('--license-title', prompt=True, default='',
               help='the name of a data license, e.g. "CC-BY-4.0"')
-@click.option('--license-path', prompt=True, default='',
+@click.option('--license-url', prompt=True, default='',
               help='a url for a data license')
 @click.option('-p', '--print', is_flag=True, is_eager=True,
               callback=print_config, expose_value=False,
@@ -124,7 +124,7 @@ def delete_config(ctx, param, value):
               callback=delete_config, expose_value=False,
               help='Delete your configuration file.')
 def config(individual_name, email, organization, position_name,
-           license_path, license_title):
+           license_url, license_title):
     contact = geometamaker.models.ContactSchema()
     contact.individual_name = individual_name
     contact.email = email
@@ -132,7 +132,7 @@ def config(individual_name, email, organization, position_name,
     contact.position_name = position_name
 
     license = geometamaker.models.LicenseSchema()
-    license.path = license_path
+    license.path = license_url
     license.title = license_title
 
     profile = geometamaker.models.Profile(contact=contact, license=license)

--- a/src/geometamaker/cli.py
+++ b/src/geometamaker/cli.py
@@ -143,6 +143,7 @@ def config(individual_name, email, organization, position_name,
               help='''Override the default verbosity of logging. Use "-vvv" for
               debug-level logging. Omit this flag for default,
               info-level logging.''')
+@click.version_option(message="%(version)s")
 def cli(verbosity):
     log_level = logging.ERROR - verbosity*10
     handler.setLevel(log_level)

--- a/src/geometamaker/cli.py
+++ b/src/geometamaker/cli.py
@@ -18,10 +18,15 @@ def main(user_args=None):
     describe_subparser.add_argument(
         'filepath',
         help=('path to a dataset to describe'))
+    validate_subparser = subparsers.add_parser(
+        'validate', help='validate a metadata document')
+    validate_subparser.add_argument(
+        'filepath',
+        help=('path to a metadata document to validate'))
 
     args = parser.parse_args(user_args)
 
-    root_logger = logging.getLogger()
+    # root_logger = logging.getLogger()
     handler = logging.StreamHandler(sys.stdout)
     formatter = logging.Formatter(
         fmt='%(asctime)s %(name)-18s %(levelname)-8s %(message)s',
@@ -30,9 +35,16 @@ def main(user_args=None):
     handler.setLevel(logging.DEBUG)  # TODO: take user input
 
     if args.subcommand == 'describe':
-        description = geometamaker.describe(args.filepath).write()
-        sys.stdout.write(pprint.pformat(description))
+        geometamaker.describe(args.filepath).write()
+        # sys.stdout.write(pprint.pformat(description))
         parser.exit()
+
+    if args.subcommand == 'validate':
+        validation_message = geometamaker.validate(args.filepath)
+        if validation_message:
+            sys.stdout.write(validation_message)
+        parser.exit()
+
 
 if __name__ == '__main__':
     main()

--- a/src/geometamaker/cli.py
+++ b/src/geometamaker/cli.py
@@ -39,7 +39,11 @@ def main(user_args=None):
     handler.setLevel(logging.DEBUG)  # TODO: take user input
 
     if args.subcommand == 'describe':
-        geometamaker.describe(args.filepath).write()
+        if os.path.isdir(args.filepath):
+            geometamaker.describe_dir(
+                args.filepath, recursive=args.recursive)
+        else:
+            geometamaker.describe(args.filepath).write()
         # sys.stdout.write(pprint.pformat(description))
         parser.exit()
 

--- a/src/geometamaker/cli.py
+++ b/src/geometamaker/cli.py
@@ -76,6 +76,17 @@ def print_config(ctx, param, value):
     ctx.exit()
 
 
+def delete_config(ctx, param, value):
+    if not value or ctx.resilient_parsing:
+        return
+    config = geometamaker.Config()
+    click.confirm(
+        f'Are you sure you want to delete {config.config_path}?',
+        abort=True)
+    config.delete()
+    ctx.exit()
+
+
 @click.command()
 @click.option('--individual_name', prompt=True, default='')
 @click.option('--email', prompt=True, default='')
@@ -85,6 +96,9 @@ def print_config(ctx, param, value):
 @click.option('--license_path', prompt=True, default='')
 @click.option('-p', '--print', is_flag=True, is_eager=True,
               callback=print_config, expose_value=False)
+@click.confirmation_option(
+    '--delete', is_flag=True, is_eager=True,
+    callback=delete_config, expose_value=False)
 def config(individual_name, email, organization, position_name,
            license_path, license_title):
     contact = geometamaker.models.ContactSchema()

--- a/src/geometamaker/cli.py
+++ b/src/geometamaker/cli.py
@@ -1,64 +1,51 @@
-import argparse
+# import argparse
 import logging
 import os
 import sys
 
+import click
+
 import geometamaker
 
-
-def main(user_args=None):
-    parser = argparse.ArgumentParser(
-        description=(
-            ''),
-        prog='geometamaker'
-    )
-
-    subparsers = parser.add_subparsers(dest='subcommand')
-    describe_subparser = subparsers.add_parser(
-        'describe', help='describe a dataset')
-    describe_subparser.add_argument(
-        'filepath',
-        help=('path to a dataset to describe'))
-    validate_subparser = subparsers.add_parser(
-        'validate', help='validate a metadata document')
-    validate_subparser.add_argument(
-        'filepath',
-        help=('path to a metadata document, or directory containing documents, to validate'))
-    validate_subparser.add_argument(
-        '-r', '--recursive', action='store_true', default=False,
-        help='recurse through subdirectories in search of metadata documents.')
-
-    args = parser.parse_args(user_args)
-
-    # root_logger = logging.getLogger()
-    handler = logging.StreamHandler(sys.stdout)
-    formatter = logging.Formatter(
-        fmt='%(asctime)s %(name)-18s %(levelname)-8s %(message)s',
-        datefmt='%m/%d/%Y %H:%M:%S ')
-    handler.setFormatter(formatter)
-    handler.setLevel(logging.DEBUG)  # TODO: take user input
-
-    if args.subcommand == 'describe':
-        if os.path.isdir(args.filepath):
-            geometamaker.describe_dir(
-                args.filepath, recursive=args.recursive)
-        else:
-            geometamaker.describe(args.filepath).write()
-        # sys.stdout.write(pprint.pformat(description))
-        parser.exit()
-
-    if args.subcommand == 'validate':
-        if os.path.isdir(args.filepath):
-            file_list, message_list = geometamaker.validate_dir(
-                args.filepath, recursive=args.recursive)
-            for filepath, msg in zip(file_list, message_list):
-                sys.stdout.write(f'{filepath}: {msg}\n')
-        else:
-            validation_message = geometamaker.validate(args.filepath)
-            if validation_message:
-                sys.stdout.write(validation_message)
-        parser.exit()
+# root_logger = logging.getLogger()
+handler = logging.StreamHandler(sys.stdout)
+formatter = logging.Formatter(
+    fmt='%(asctime)s %(name)-18s %(levelname)-8s %(message)s',
+    datefmt='%m/%d/%Y %H:%M:%S ')
+handler.setFormatter(formatter)
+handler.setLevel(logging.DEBUG)  # TODO: take user input
 
 
-if __name__ == '__main__':
-    main()
+@click.group()
+def cli():
+    pass
+
+
+@click.command()
+@click.argument('filepath')
+@click.option('-r', '--recursive', is_flag=True, default=False)
+def describe(filepath, recursive):
+    if os.path.isdir(filepath):
+        geometamaker.describe_dir(
+            filepath, recursive=recursive)
+    else:
+        geometamaker.describe(filepath).write()
+
+
+@click.command()
+@click.argument('filepath')
+@click.option('-r', '--recursive', is_flag=True, default=False)
+def validate(filepath, recursive):
+    if os.path.isdir(filepath):
+        file_list, message_list = geometamaker.validate_dir(
+            filepath, recursive=recursive)
+        for filepath, msg in zip(file_list, message_list):
+            click.echo(f'{filepath}: {msg}\n')
+    else:
+        validation_message = geometamaker.validate(filepath)
+        if validation_message:
+            click.echo(validation_message)
+
+
+cli.add_command(describe)
+cli.add_command(validate)

--- a/src/geometamaker/cli.py
+++ b/src/geometamaker/cli.py
@@ -47,5 +47,41 @@ def validate(filepath, recursive):
             click.echo(validation_message)
 
 
+def print_config(ctx, param, value):
+    if not value or ctx.resilient_parsing:
+        return
+    config = geometamaker.Config()
+    click.echo(f'{config.profile}')
+    ctx.exit()
+
+
+@click.command()
+@click.option('--individual_name', prompt=True, default='')
+@click.option('--email', prompt=True, default='')
+@click.option('--organization', prompt=True, default='')
+@click.option('--position_name', prompt=True, default='')
+@click.option('--license_title', prompt=True, default='')
+@click.option('--license_path', prompt=True, default='')
+@click.option('-p', '--print', is_flag=True, is_eager=True, callback=print_config, expose_value=False)
+def config(individual_name, email, organization, position_name,
+           license_path, license_title):
+    contact = geometamaker.models.ContactSchema()
+    contact.individual_name = individual_name
+    contact.email = email
+    contact.organization = organization
+    contact.position_name = position_name
+
+    license = geometamaker.models.LicenseSchema()
+    license.path = license_path
+    license.title = license_title
+
+    profile = geometamaker.models.Profile(contact=contact, license=license)
+    # click.echo(f'{profile}')
+    config = geometamaker.Config()
+    config.save(profile)
+    click.echo(f'saved profile information to {config.config_path}')
+
+
 cli.add_command(describe)
 cli.add_command(validate)
+cli.add_command(config)

--- a/src/geometamaker/cli.py
+++ b/src/geometamaker/cli.py
@@ -7,13 +7,16 @@ from pydantic import ValidationError
 
 import geometamaker
 
-# root_logger = logging.getLogger()
+root_logger = logging.getLogger()
+root_logger.setLevel(logging.DEBUG)
 handler = logging.StreamHandler(sys.stdout)
 formatter = logging.Formatter(
     fmt='%(asctime)s %(name)-18s %(levelname)-8s %(message)s',
     datefmt='%m/%d/%Y %H:%M:%S ')
 handler.setFormatter(formatter)
-handler.setLevel(logging.DEBUG)  # TODO: take user input
+handler.setLevel(logging.INFO)  # TODO: take user input
+root_logger.addHandler(handler)
+# import pdb; pdb.set_trace()
 
 
 @click.group()

--- a/src/geometamaker/cli.py
+++ b/src/geometamaker/cli.py
@@ -16,7 +16,17 @@ formatter = logging.Formatter(
 handler.setFormatter(formatter)
 handler.setLevel(logging.INFO)  # TODO: take user input
 root_logger.addHandler(handler)
-# import pdb; pdb.set_trace()
+
+
+def echo_validation_error(error, filepath):
+    summary = u'\u2715' + f' {filepath}: {error.error_count()} validation errors'
+    click.secho(summary, fg='bright_red')
+    for e in error.errors():
+        location = ', '.join(e['loc'])
+        msg_string = (f"    {e['msg']}. [input_value={e['input']}, "
+                      f"input_type={type(e['input']).__name__}]")
+        click.secho(location, bold=True)
+        click.secho(msg_string)
 
 
 @click.group()
@@ -33,17 +43,6 @@ def describe(filepath, recursive):
             filepath, recursive=recursive)
     else:
         geometamaker.describe(filepath).write()
-
-
-def echo_validation_error(error, filepath):
-    summary = u'\u2715' + f' {filepath}: {error.error_count()} validation errors'
-    click.secho(summary, fg='bright_red')
-    for e in error.errors():
-        location = ', '.join(e['loc'])
-        msg_string = (f"    {e['msg']}. [input_value={e['input']}, "
-                      f"input_type={type(e['input']).__name__}]")
-        click.secho(location, bold=True)
-        click.secho(msg_string)
 
 
 @click.command()

--- a/src/geometamaker/cli.py
+++ b/src/geometamaker/cli.py
@@ -1,0 +1,38 @@
+import argparse
+import logging
+import pprint
+import sys
+
+import geometamaker
+
+def main(user_args=None):
+    parser = argparse.ArgumentParser(
+        description=(
+            ''),
+        prog='geometamaker'
+    )
+
+    subparsers = parser.add_subparsers(dest='subcommand')
+    describe_subparser = subparsers.add_parser(
+        'describe', help='describe a dataset')
+    describe_subparser.add_argument(
+        'filepath',
+        help=('path to a dataset to describe'))
+
+    args = parser.parse_args(user_args)
+
+    root_logger = logging.getLogger()
+    handler = logging.StreamHandler(sys.stdout)
+    formatter = logging.Formatter(
+        fmt='%(asctime)s %(name)-18s %(levelname)-8s %(message)s',
+        datefmt='%m/%d/%Y %H:%M:%S ')
+    handler.setFormatter(formatter)
+    handler.setLevel(logging.DEBUG)  # TODO: take user input
+
+    if args.subcommand == 'describe':
+        description = geometamaker.describe(args.filepath).write()
+        sys.stdout.write(pprint.pformat(description))
+        parser.exit()
+
+if __name__ == '__main__':
+    main()

--- a/src/geometamaker/config.py
+++ b/src/geometamaker/config.py
@@ -58,5 +58,8 @@ class Config(object):
 
     def delete(self):
         """Delete the config file."""
-        LOGGER.info(f'removing {self.config_path}')
-        os.remove(self.config_path)
+        try:
+            os.remove(self.config_path)
+            LOGGER.info(f'removed {self.config_path}')
+        except FileNotFoundError as error:
+            LOGGER.debug(error)

--- a/src/geometamaker/geometamaker.py
+++ b/src/geometamaker/geometamaker.py
@@ -446,8 +446,8 @@ def validate_dir(directory, recursive=False):
             in all subdirectories
 
     Returns:
-        tuple (list, list): a list of validation messages and an equal-length
-            list of the filepaths that were validated.
+        tuple (list, list): a list of the filepaths that were validated and
+            an equal-length list of the validation messages.
 
     """
     file_list = []

--- a/src/geometamaker/geometamaker.py
+++ b/src/geometamaker/geometamaker.py
@@ -406,7 +406,6 @@ def describe(source_dataset_path, profile=None):
 
 
 def validate(filepath):
-    validation_messages = None
     with fsspec.open(filepath, 'r') as file:
         yaml_string = file.read()
         yaml_dict = yaml.safe_load(yaml_string)
@@ -419,15 +418,7 @@ def validate(filepath):
     try:
         RESOURCE_MODELS[yaml_dict['type']](**yaml_dict)
     except ValidationError as error:
-        error_list = [
-            f'{error.error_count()} validation errors for {filepath}:']
-        for e in error.errors():
-            error_list.append(', '.join(e['loc']))
-            error_list.append(
-                f"  {e['msg']}. [input_value={e['input']}, input_type={type(e['input']).__name__}]")
-        validation_messages = '\n'.join(error_list)
-
-    return validation_messages
+        return error
 
 
 def validate_dir(directory, recursive=False):
@@ -448,11 +439,11 @@ def validate_dir(directory, recursive=False):
         if filepath.endswith('.yml'):
             yaml_files.append(filepath)
             try:
-                msg = validate(filepath)
-                if msg:
-                    messages.append(msg)
+                error = validate(filepath)
+                if error:
+                    messages.append(error)
                 else:
-                    messages.append('valid')
+                    messages.append('')
             except ValueError:
                 messages.append(
                     'does not appear to be a geometamaker document')

--- a/src/geometamaker/geometamaker.py
+++ b/src/geometamaker/geometamaker.py
@@ -456,3 +456,23 @@ def validate_dir(directory, recursive=False):
                     'does not appear to be a geometamaker document')
 
     return (yaml_files, messages)
+
+
+def describe_dir(directory, recursive=False):
+    file_list = []
+    if recursive:
+        for path, dirs, files in os.walk(directory):
+            for file in files:
+                file_list.append(os.path.join(path, file))
+    else:
+        file_list.extend(
+            [os.path.join(directory, path) for path in os.listdir(directory)])
+
+    for filepath in file_list:
+        try:
+            resource = describe(filepath)
+        except ValueError as error:
+            LOGGER.debug(error)
+            continue
+        LOGGER.info(f'writing metadata for {filepath}')
+        resource.write()

--- a/src/geometamaker/geometamaker.py
+++ b/src/geometamaker/geometamaker.py
@@ -438,7 +438,9 @@ def validate_dir(directory, recursive=False):
                 file_list.append(os.path.join(path, file))
     else:
         file_list.extend(
-            [os.path.join(directory, path) for path in os.listdir(directory)])
+            [os.path.join(directory, path)
+                for path in os.listdir(directory)
+                if os.path.isfile(os.path.join(directory, path))])
 
     messages = []
     yaml_files = []
@@ -466,7 +468,9 @@ def describe_dir(directory, recursive=False):
                 file_list.append(os.path.join(path, file))
     else:
         file_list.extend(
-            [os.path.join(directory, path) for path in os.listdir(directory)])
+            [os.path.join(directory, path)
+                for path in os.listdir(directory)
+                if os.path.isfile(os.path.join(directory, path))])
 
     for filepath in file_list:
         try:

--- a/src/geometamaker/geometamaker.py
+++ b/src/geometamaker/geometamaker.py
@@ -407,6 +407,21 @@ def describe(source_dataset_path, profile=None):
 
 
 def validate(filepath):
+    """Validate a YAML metadata document.
+
+    Validation includes type-checking of property values and
+    checking for the presence of required properties.
+
+    Args:
+        directory (string): path to a YAML file
+
+    Returns:
+        pydantic.ValidationError
+
+    Raises:
+        ValueError if the YAML document is not a geometamaker metadata doc.
+
+    """
     with fsspec.open(filepath, 'r') as file:
         yaml_string = file.read()
         yaml_dict = yaml.safe_load(yaml_string)
@@ -423,6 +438,18 @@ def validate(filepath):
 
 
 def validate_dir(directory, recursive=False):
+    """Validate all compatible yml documents in the directory.
+
+    Args:
+        directory (string): path to a directory
+        recursive (bool): whether or not to describe files
+            in all subdirectories
+
+    Returns:
+        tuple (list, list): a list of validation messages and an equal-length
+            list of the filepaths that were validated.
+
+    """
     file_list = []
     if recursive:
         for path, dirs, files in os.walk(directory):

--- a/tests/test_geometamaker.py
+++ b/tests/test_geometamaker.py
@@ -1003,7 +1003,7 @@ class CLITests(unittest.TestCase):
             'organization': 'org',
             'position_name': 'position',
             'license_title': 'license',
-            'license_path': ''
+            'license_url': ''
         }
         result = runner.invoke(cli.cli, ['config'],
                                input='\n'.join(inputs.values()) + '\n')
@@ -1015,7 +1015,7 @@ class CLITests(unittest.TestCase):
         self.assertEqual(profile.contact.organization, inputs['organization'])
         self.assertEqual(profile.contact.position_name, inputs['position_name'])
         self.assertEqual(profile.license.title, inputs['license_title'])
-        self.assertEqual(profile.license.path, inputs['license_path'])
+        self.assertEqual(profile.license.path, inputs['license_url'])
 
     @patch('geometamaker.config.platformdirs.user_config_dir')
     def test_cli_config_print(self, mock_user_config_dir):

--- a/tests/test_geometamaker.py
+++ b/tests/test_geometamaker.py
@@ -624,13 +624,21 @@ class GeometamakerTests(unittest.TestCase):
         with open(resource.metadata_path, 'w') as file:
             file.write(utils.yaml_dump(yaml_dict))
 
-        msgs = geometamaker.validate(resource.metadata_path)
-        print(msgs)
-        self.assertIn('2 validation errors', msgs)
-        self.assertIn('foo', msgs)
-        self.assertIn('Extra inputs are not permitted', msgs)
-        self.assertIn('keywords', msgs)
-        self.assertIn('Input should be a valid list', msgs)
+        error = geometamaker.validate(resource.metadata_path)
+        print(error)
+        # self.assertIn('2 validation errors', msg_dict['summary'])
+        # self.assertIn('foo', msg_dict['errors'])
+        # self.assertIn('Extra inputs are not permitted', msg_dict['errors']['foo'])
+        # self.assertIn('keywords', msg_dict['errors'])
+        # self.assertIn('Input should be a valid list', msg_dict['errors']['keywords'])
+        self.assertEqual(error.error_count(), 2)
+        msg_dict = {', '.join(e['loc']): e['msg'] for e in error.errors()}
+        # locations = [e['loc'] for e in error.errors()]
+        # messages = [e['msg'] for e in error.errors()]
+        self.assertIn('foo', msg_dict)
+        self.assertIn('Extra inputs are not permitted', msg_dict['foo'])
+        self.assertIn('keywords', msg_dict)
+        self.assertIn('Input should be a valid list', msg_dict['keywords'])
 
     def test_describe_validate_dir(self):
         """Test describe and validate functions that walk directory tree."""

--- a/tests/test_geometamaker.py
+++ b/tests/test_geometamaker.py
@@ -626,16 +626,9 @@ class GeometamakerTests(unittest.TestCase):
             file.write(utils.yaml_dump(yaml_dict))
 
         error = geometamaker.validate(resource.metadata_path)
-        print(error)
-        # self.assertIn('2 validation errors', msg_dict['summary'])
-        # self.assertIn('foo', msg_dict['errors'])
-        # self.assertIn('Extra inputs are not permitted', msg_dict['errors']['foo'])
-        # self.assertIn('keywords', msg_dict['errors'])
-        # self.assertIn('Input should be a valid list', msg_dict['errors']['keywords'])
+
         self.assertEqual(error.error_count(), 2)
         msg_dict = {', '.join(e['loc']): e['msg'] for e in error.errors()}
-        # locations = [e['loc'] for e in error.errors()]
-        # messages = [e['msg'] for e in error.errors()]
         self.assertIn('foo', msg_dict)
         self.assertIn('Extra inputs are not permitted', msg_dict['foo'])
         self.assertIn('keywords', msg_dict)

--- a/tests/test_geometamaker.py
+++ b/tests/test_geometamaker.py
@@ -1012,9 +1012,8 @@ class CLITests(unittest.TestCase):
             'license_title': 'license',
             'license_path': ''
         }
-        print(inputs.values())
         result = runner.invoke(cli.cli, ['config'],
-                               input='\n'.join(inputs.values()))
+                               input='\n'.join(inputs.values()) + '\n')
         self.assertEqual(result.exit_code, 0)
 
         profile = config.Config().profile


### PR DESCRIPTION
This PR adds a command-line interface.

I also added `geometamaker.describe_dir` and `geometamaker.validate_dir` to more easily process a batch of files in a directory tree.

Fixes #43 

### --help
```
λ geometamaker --help
Usage: geometamaker [OPTIONS] COMMAND [ARGS]...

Options:
  -v         Override the default verbosity of logging. Use "-vvv" for debug-
             level logging. Omit this flag for default, info-level logging.
  --version  Show the version and exit.
  --help     Show this message and exit.

Commands:
  config    Configure GeoMetaMaker with information to apply to all metadata
            descriptions
  describe  Generate metadata for geospatial or tabular data, or zip archives.
  validate  Validate metadata documents for syntax or type errors.
```

```
λ geometamaker describe --help
Usage: geometamaker describe [OPTIONS] FILEPATH

  Describe properties of a dataset given by FILEPATH and write this metadata
  to a .yml sidecar file. Or if FILEPATH is a directory, describe all datasets
  within.

Options:
  -r, --recursive  if FILEPATH is a directory, describe files in all
                   subdirectories
  -nw, --no-write  Dump metadata to stdout instead of to a .yml file. This
                   option is ignored if `filepath` is a directory
  --help           Show this message and exit.
```

```
λ geometamaker validate --help
Usage: geometamaker validate [OPTIONS] FILEPATH

  Validate a .yml metadata document given by FILEPATH. Or if FILEPATH is a
  directory, validate all documents within.

Options:
  -r, --recursive  if `filepath` is a directory, validate documents in all
                   subdirectories.
  --help           Show this message and exit.
```

```
λ geometamaker config --help
Usage: geometamaker config [OPTIONS]

  When prompted, enter contact and data-license information that will be
  stored in a user profile. This information will automatically populate
  contact and license sections of any metadata described on your system. Press
  enter to leave any field blank.

Options:
  --individual-name TEXT
  --email TEXT
  --organization TEXT
  --position-name TEXT
  --license-title TEXT    the name of a data license, e.g. "CC-BY-4.0"
  --license-path TEXT     a url for a data license
  -p, --print             Print your current GeoMetaMaker configuration.
  --delete                Delete your configuration file.
  --help                  Show this message and exit.
```

### Some examples:
```
(C:\Users\dmf\projects\geometamaker\env) λ geometamaker describe data
01/06/2025 11:24:12  geometamaker.geometamaker INFO     data\data_no_csv.zip described
01/06/2025 11:24:12  geometamaker.geometamaker INFO     data\carbon_pools.csv described
01/06/2025 11:24:13  geometamaker.geometamaker WARNING  LOCAL_CS["Undefined SRS",LOCAL_DATUM["unknown",32767],UNIT["unknown",0],AXIS["Easting",EAST],AXIS["Northing",NORTH]] cannot be interpreted as a coordinate reference system
01/06/2025 11:24:13  geometamaker.geometamaker INFO     data\foo.gpkg described
01/06/2025 11:24:13  geometamaker.geometamaker INFO     data\data.zip described
```

```
(C:\Users\dmf\projects\geometamaker\env) λ geometamaker validate data
○ data\bad_config.yml does not appear to be a geometamaker document
✓ data\carbon_pools.csv.yml
✓ data\data.zip.yml
✓ data\data_no_csv.zip.yml
✕ data\DEM_gura.tif.yml: 2 validation errors
edition
    Input should be a valid string. [input_value=2, input_type=int]
keywords
    Input should be a valid list. [input_value=hello world keywords, input_type=str]
✓ data\foo.gpkg.yml
✕ data\watershed_gura.shp.yml: 1 validation errors
keywords
    Input should be a valid list. [input_value=foo bar, input_type=str]
```