### PR TITLE
Minor updates to data models

### DIFF
--- a/src/geometamaker/geometamaker.py
+++ b/src/geometamaker/geometamaker.py
@@ -179,6 +179,9 @@ def describe_file(source_dataset_path, scheme):
         f'{description["bytes"]}{description["last_modified"]}\
         {description["path"]}'.encode('ascii'))
     description['uid'] = f'sizetimestamp:{hash_func.hexdigest()}'
+
+    # We don't have a use for including this attribute in our metadata:
+    description.pop('mediatype', None)
     return description
 
 
@@ -196,7 +199,7 @@ def describe_archive(source_dataset_path, scheme):
     description = describe_file(source_dataset_path, scheme)
     # innerpath is from frictionless and not useful because
     # it does not include all the files contained in the zip
-    del description['innerpath']
+    description.pop('innerpath', None)
 
     ZFS = fsspec.get_filesystem_class('zip')
     zfs = ZFS(source_dataset_path)
@@ -425,8 +428,8 @@ def validate(filepath):
     with fsspec.open(filepath, 'r') as file:
         yaml_string = file.read()
         yaml_dict = yaml.safe_load(yaml_string)
-        if not yaml_dict or 'metadata_version' not in yaml_dict \
-                or not yaml_dict['metadata_version'].startswith('geometamaker'):
+        if not yaml_dict or ('metadata_version' not in yaml_dict
+                             and 'geometamaker_version' not in yaml_dict):
             message = (f'{filepath} exists but is not compatible with '
                        f'geometamaker.')
             raise ValueError(message)

--- a/src/geometamaker/geometamaker.py
+++ b/src/geometamaker/geometamaker.py
@@ -28,7 +28,7 @@ PROTOCOLS = [
     'https',
 ]
 
-DT_FMT = '%Y-%m-%d %H:%M:%S'
+DT_FMT = '%Y-%m-%d %H:%M:%S %Z'
 
 
 # TODO: In the future we can remove these exception managers in favor of the

--- a/src/geometamaker/geometamaker.py
+++ b/src/geometamaker/geometamaker.py
@@ -273,7 +273,8 @@ def describe_raster(source_dataset_path, scheme):
     description['data_model'] = models.RasterSchema(
         bands=bands,
         pixel_size=info['pixel_size'],
-        raster_size=info['raster_size'])
+        raster_size={'width': info['raster_size'][0],
+                     'height': info['raster_size'][1]})
     # Some values of raster info are numpy types, which the
     # yaml dumper doesn't know how to represent.
     bbox = models.BoundingBox(*[float(x) for x in info['bounding_box']])

--- a/src/geometamaker/geometamaker.py
+++ b/src/geometamaker/geometamaker.py
@@ -180,8 +180,9 @@ def describe_file(source_dataset_path, scheme):
         {description["path"]}'.encode('ascii'))
     description['uid'] = f'sizetimestamp:{hash_func.hexdigest()}'
 
-    # We don't have a use for including this attribute in our metadata:
+    # We don't have a use for including these attributes in our metadata:
     description.pop('mediatype', None)
+    description.pop('name', None)
     return description
 
 

--- a/src/geometamaker/models.py
+++ b/src/geometamaker/models.py
@@ -263,7 +263,6 @@ class Resource(BaseMetadata):
     encoding: str = ''
     format: str = ''
     uid: str = ''
-    name: str = ''
     path: str = ''
     scheme: str = ''
     type: str = ''
@@ -317,7 +316,7 @@ class Resource(BaseMetadata):
                        f'geometamaker.')
             raise ValueError(message)
 
-        deprecated_attrs = ['metadata_version', 'mediatype']
+        deprecated_attrs = ['metadata_version', 'mediatype', 'name']
         for attr in deprecated_attrs:
             if attr in yaml_dict:
                 warnings.warn(

--- a/src/geometamaker/models.py
+++ b/src/geometamaker/models.py
@@ -255,7 +255,7 @@ class Resource(BaseMetadata):
     """
 
     # A version string we can use to identify geometamaker compliant documents
-    metadata_version: str = ''
+    geometamaker_version: str = ''
     metadata_path: str = ''
 
     # These are populated geometamaker.describe()
@@ -289,7 +289,7 @@ class Resource(BaseMetadata):
 
     def model_post_init(self, __context):
         self.metadata_path = f'{self.path}.yml'
-        self.metadata_version: str = f'geometamaker.{geometamaker.__version__}'
+        self.geometamaker_version: str = geometamaker.__version__
         self.path = self.path.replace('\\', '/')
         self.sources = [x.replace('\\', '/') for x in self.sources]
 

--- a/src/geometamaker/models.py
+++ b/src/geometamaker/models.py
@@ -102,7 +102,7 @@ class RasterSchema(Parent):
 
     bands: List[BandSchema]
     pixel_size: list
-    raster_size: dict | list
+    raster_size: Union[dict, list]
 
     def model_post_init(self, __context):
         # Migrate from previous model where we stored this as a list

--- a/src/geometamaker/models.py
+++ b/src/geometamaker/models.py
@@ -102,7 +102,13 @@ class RasterSchema(Parent):
 
     bands: List[BandSchema]
     pixel_size: list
-    raster_size: list
+    raster_size: dict | list
+
+    def model_post_init(self, __context):
+        # Migrate from previous model where we stored this as a list
+        if isinstance(self.raster_size, list):
+            self.raster_size = {'width': self.raster_size[0],
+                                'height': self.raster_size[1]}
 
 
 class BaseMetadata(Parent):

--- a/src/geometamaker/models.py
+++ b/src/geometamaker/models.py
@@ -263,7 +263,6 @@ class Resource(BaseMetadata):
     encoding: str = ''
     format: str = ''
     uid: str = ''
-    mediatype: str = ''
     name: str = ''
     path: str = ''
     scheme: str = ''
@@ -312,14 +311,22 @@ class Resource(BaseMetadata):
         with fsspec.open(filepath, 'r') as file:
             yaml_string = file.read()
         yaml_dict = yaml.safe_load(yaml_string)
-        if 'metadata_version' not in yaml_dict \
-                or not yaml_dict['metadata_version'].startswith('geometamaker'):
+        if not yaml_dict or ('metadata_version' not in yaml_dict
+                             and 'geometamaker_version' not in yaml_dict):
             message = (f'{filepath} exists but is not compatible with '
                        f'geometamaker.')
             raise ValueError(message)
-        # delete this property so that geometamaker can initialize it itself
-        # with the current version info.
-        del yaml_dict['metadata_version']
+
+        deprecated_attrs = ['metadata_version', 'mediatype']
+        for attr in deprecated_attrs:
+            if attr in yaml_dict:
+                warnings.warn(
+                    f'"{attr}" exists in {filepath} but is no longer part of '
+                    f'the geometamaker specification. "{attr}" will be '
+                    f'removed from this document. In the future, presence '
+                    f' of "{attr}" will raise a ValidationError',
+                    category=FutureWarning)
+                del yaml_dict[attr]
 
         # migrate from 'schema' to 'data_model', if needed.
         if 'schema' in yaml_dict:

--- a/src/geometamaker/utils.py
+++ b/src/geometamaker/utils.py
@@ -26,4 +26,5 @@ def yaml_dump(data):
     return yaml.dump(
         data,
         allow_unicode=True,
+        sort_keys=False,
         Dumper=_SafeDumper)


### PR DESCRIPTION
Based on feedback, we have a few changes to attributes:

`mediatype`: removed, not useful
`name`: removed, not useful, redundant with `path` and too easily confused with `title`
`raster_size`: changed from `list` to `dict` to allow "width" and "height" labels
`metadata_version`: changed to `geometamaker_version` to be more accurate

All these changes are made backwards-compatible with respect to `describing` a dataset with an existing `yml` document.  When a pre-existing document is loaded, incompatible attributes are removed/replaced with warnings issued.

`validate` will issue `ValidationErrors` on a document with the old attributes.

Fixes #58 