### PR TITLE
Various bugfixes

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
         os: [ubuntu-latest, windows-latest, macos-latest]
 
     steps:

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,12 @@ Release History
 ===============
 
 .. Unreleased Changes
+* Fixed a bug where rasters without a defined nodata value could not be
+  described. https://github.com/natcap/geometamaker/issues/70
+* All YAML documents will be written as UTF-8 encoded files.
+  https://github.com/natcap/geometamaker/issues/71
+* Fixed a bug in formatting of validation messages about nested attributes
+  https://github.com/natcap/geometamaker/issues/65
 
 0.1.0 (2025-01-10)
 ------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = "geometamaker"
 description = "metadata creation for geospatial data"
 readme = "README.md"
-requires-python = ">=3.9,<3.13"
+requires-python = ">=3.9"
 license = {file = "LICENSE.txt"}
 maintainers = [
     {name = "Natural Capital Project Software Team"}
@@ -21,6 +21,7 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "License :: OSI Approved :: BSD License",
     "Topic :: Scientific/Engineering :: GIS"
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,10 +6,10 @@ aiohttp
 click
 fsspec
 GDAL
-frictionless
+frictionless>=5.18.0
 numpy
 platformdirs
-Pydantic
+Pydantic>=2.0
 pygeoprocessing>=2.4.5
 pyyaml
 requests

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ aiohttp
 click
 fsspec
 GDAL
-frictionless>=5.18.0
+frictionless>=5.10.0
 numpy
 platformdirs
 Pydantic>=2.0

--- a/src/geometamaker/cli.py
+++ b/src/geometamaker/cli.py
@@ -48,7 +48,7 @@ def echo_validation_error(error, filepath):
     summary = u'\u2715' + f' {filepath}: {error.error_count()} validation errors'
     click.secho(summary, fg='bright_red')
     for e in error.errors():
-        location = ', '.join(e['loc'])
+        location = '.'.join([str(loc) for loc in e['loc']])
         msg_string = (f"    {e['msg']}. [input_value={e['input']}, "
                       f"input_type={type(e['input']).__name__}]")
         click.secho(location, bold=True)

--- a/src/geometamaker/models.py
+++ b/src/geometamaker/models.py
@@ -242,7 +242,7 @@ class Profile(BaseMetadata):
             target_path (str): path to a yaml file to be written
 
         """
-        with open(target_path, 'w') as file:
+        with open(target_path, 'w', encoding='utf-8') as file:
             file.write(utils.yaml_dump(self.model_dump()))
 
 
@@ -523,7 +523,7 @@ class Resource(BaseMetadata):
             target_path = os.path.join(
                 workspace, os.path.basename(self.metadata_path))
 
-        with open(target_path, 'w') as file:
+        with open(target_path, 'w', encoding='utf-8') as file:
             file.write(utils.yaml_dump(
                 self.model_dump(exclude=['metadata_path'])))
 

--- a/src/geometamaker/models.py
+++ b/src/geometamaker/models.py
@@ -91,7 +91,7 @@ class BandSchema(Parent):
     index: int
     gdal_type: str
     numpy_type: str
-    nodata: Union[int, float]
+    nodata: Union[int, float, None]
     description: str = ''
     title: str = ''
     units: str = ''


### PR DESCRIPTION
Various small bugfixes. 

Fixes #71 - always write utf-8 documents
Fixes #65 - fix validation message formatting for attributes nested in a list
Fixes #64 - minimum version requirements for pydantic and frictionless
Fixes #46 - test against python 3.13
Fixes #70 - don't fail on rasters that have no nodata value.