### PR TITLE
added exception handling to `validate_dir`

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -8,6 +8,8 @@ Release History
   https://github.com/natcap/geometamaker/issues/71
 * Fixed a bug in formatting of validation messages about nested attributes
   https://github.com/natcap/geometamaker/issues/65
+* Added exception handling to make validating directories more resilient to
+  unreadable yaml files. https://github.com/natcap/geometamaker/issues/62
 
 0.1.0 (2025-01-10)
 ------------------

--- a/src/geometamaker/geometamaker.py
+++ b/src/geometamaker/geometamaker.py
@@ -471,15 +471,17 @@ def validate_dir(directory, recursive=False):
     for filepath in file_list:
         if filepath.endswith('.yml'):
             yaml_files.append(filepath)
+            msg = ''
             try:
                 error = validate(filepath)
                 if error:
-                    messages.append(error)
-                else:
-                    messages.append('')
+                    msg = error
             except ValueError:
-                messages.append(
-                    'does not appear to be a geometamaker document')
+                msg = 'does not appear to be a geometamaker document'
+            except yaml.YAMLError as exc:
+                LOGGER.debug(exc)
+                msg = 'is not a readable yaml document'
+            messages.append(msg)
 
     return (yaml_files, messages)
 

--- a/tests/test_geometamaker.py
+++ b/tests/test_geometamaker.py
@@ -676,6 +676,22 @@ class GeometamakerTests(unittest.TestCase):
             self.workspace_dir, recursive=True)
         self.assertEqual(len(yaml_files), 2)
 
+    def test_validate_dir_handles_exception(self):
+        """Test validate_dir function handles yaml exceptions."""
+        import geometamaker
+
+        yaml_path = os.path.join(self.workspace_dir, 'foo.yml')
+        with open(yaml_path, 'w') as file:
+            # An example from a yaml file containing some jinja templating.
+            # This should raise a yaml.scanner.ScannerError:
+            # while scanning for the next token
+            # found character '%' that cannot start any token
+            file.write('{% set name = "simplejson" %}')
+
+        yaml_files, msgs = geometamaker.validate_dir(self.workspace_dir)
+        self.assertEqual(len(yaml_files), 1)
+        self.assertEqual(msgs[0], 'is not a readable yaml document')
+
     def test_describe_dir_with_shapefile(self):
         """Test describe directory containing a multi-file dataset."""
         import geometamaker


### PR DESCRIPTION
Avoid a runtime error if we encounter an unreadable yaml file while validating a directory. If a user wants to validate a specific file -- not a whole directory -- then I think it's best to not handle the exception.

Fixes #62 