### PR TITLE
include dependencies from file in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,9 @@ classifiers = [
 # using the corresponding setup args `install_requires` and `extras_require`
 dynamic = ["version", "dependencies", "optional-dependencies"]
 
+[tool.setuptools.dynamic]
+dependencies = {file = ["requirements.txt"]}
+
 [tool.setuptools_scm]
 version_scheme = "post-release"
 local_scheme = "node-and-date"


### PR DESCRIPTION
I overlooked the need to list dependencies anywhere besides `requirements.txt`. But then I realized that a simple `pip install` was not installing any dependencies. 

The feature I used here is listed as "BETA" in the docs, but it works -- `pip install` discovers and installs missing dependencies. This project is not using `setup.py`. Please let me know if you know of a better approach. Thanks!
https://setuptools.pypa.io/en/latest/userguide/pyproject_config.html#dynamic-metadata