### PR TITLE
allow CLI to describe remote datasets.

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,9 @@ Release History
 ===============
 
 .. Unreleased Changes
+---------------------
+* Allow CLI to ``describe`` remote datasets.
+  https://github.com/natcap/geometamaker/issues/78
 
 0.1.2 (2025-02-05)
 ------------------

--- a/src/geometamaker/cli.py
+++ b/src/geometamaker/cli.py
@@ -34,9 +34,9 @@ class _ParamUnion(click.ParamType):
 
     def convert(self, value, param, ctx):
         errors = []
-        for type in self.types:
+        for type_ in self.types:
             try:
-                return type.convert(value, param, ctx)
+                return type_.convert(value, param, ctx)
             except click.BadParameter as e:
                 errors.append(e)
                 continue


### PR DESCRIPTION
`geometamaker.describe` is already setup to handle reading from remote sources, but CLI validation was preventing that for `geometamaker describe`. I updated the argument validation to handle a URL or a local filepath.

Fixes #78 