### PR TITLE
Updated API docs; including docstrings for model attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,18 @@
-A Python library for creating human and machine-readable metadata for geospatial data.
+## Introduction
+
+GeoMetaMaker is a Python library for creating human and machine-readable
+metadata for geospatial, tabular, and other data formats.
 
 Supported datatypes include:
 * everything supported by GDAL
 * tabular formats supported by `frictionless`
 * compressed formats supported by `frictionless`
 
+## Installation
 
-See `requirements.txt` for dependencies.
+`mamba install -c conda-forge geometamaker`
+
+## Basic Usage
 
 This library comes with a command-line interface (CLI) called `geometamaker`.
 Many of the examples below show how to use the Python interface, and then
@@ -43,6 +49,8 @@ resource.set_band_description(
 
 resource.write()
 ```
+For a complete list of methods and attributes:
+https://geometamaker.readthedocs.io/en/latest/index.html
 
 ##### CLI
 ```
@@ -168,6 +176,3 @@ geometamaker config
 ```
 This will prompt the user to enter their profile information.  
 Also see `geometamaker config --help`.
-
-### For a complete list of methods:
-https://geometamaker.readthedocs.io/en/latest/api/geometamaker.html

--- a/docs/environment-rtd.yml
+++ b/docs/environment-rtd.yml
@@ -9,6 +9,7 @@ channels:
     - conda-forge
 dependencies:
     - python=3.10
+    - pip
     - frictionless
     - fsspec
     - gdal>=3
@@ -16,5 +17,6 @@ dependencies:
     - pygeoprocessing>=2.4.2
     - pyyaml
     - sphinx_rtd_theme
-    - autodoc_pydantic
     - myst-parser
+    - pip:
+        - autodoc_pydantic

--- a/docs/environment-rtd.yml
+++ b/docs/environment-rtd.yml
@@ -16,3 +16,4 @@ dependencies:
     - pygeoprocessing>=2.4.2
     - pyyaml
     - sphinx_rtd_theme
+    - autodoc_pydantic

--- a/docs/environment-rtd.yml
+++ b/docs/environment-rtd.yml
@@ -17,3 +17,4 @@ dependencies:
     - pyyaml
     - sphinx_rtd_theme
     - autodoc_pydantic
+    - myst-parser

--- a/docs/source/archive_resource.rst
+++ b/docs/source/archive_resource.rst
@@ -1,0 +1,6 @@
+Archive Resource
+================
+.. autopydantic_model:: geometamaker.models.ArchiveResource
+    :inherited-members: BaseModel
+    :model-show-json: True
+    :no-index:

--- a/docs/source/basic_usage.rst
+++ b/docs/source/basic_usage.rst
@@ -2,3 +2,4 @@ Basic Usage
 ===========
 .. include:: ../../README.md
    :parser: myst_parser.sphinx_
+   :start-after: Basic Usage

--- a/docs/source/basic_usage.rst
+++ b/docs/source/basic_usage.rst
@@ -1,0 +1,4 @@
+Basic Usage
+===========
+.. include:: ../../README.md
+   :parser: myst_parser.sphinx_

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -27,6 +27,7 @@ extensions = [
     'sphinx.ext.napoleon',  # support google style docstrings
     'sphinx.ext.autosummary',
     'sphinxcontrib.autodoc_pydantic',
+    'myst_parser',
 ]
 
 templates_path = ['_templates']

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -26,6 +26,7 @@ extensions = [
     'sphinx.ext.viewcode',
     'sphinx.ext.napoleon',  # support google style docstrings
     'sphinx.ext.autosummary',
+    'sphinxcontrib.autodoc_pydantic',
 ]
 
 templates_path = ['_templates']
@@ -45,6 +46,29 @@ html_static_path = ['_static']
 # need to be so picky.
 nitpicky = False
 autoclass_content = 'both'
+
+autodoc_pydantic_model_show_json = False
+autodoc_pydantic_model_show_config_summary = False
+autodoc_pydantic_model_show_field_summary = False
+
+
+def setup(app):
+    app.connect('autodoc-process-docstring',
+                process_module_specific_docstrings)
+
+
+def process_module_specific_docstrings(app, what, name, obj, options, lines):
+    """Strip inherited __init__ docstring from Pydantic models.
+
+    Remove the __init__ docstring content because
+    Pydantic models generate their own __init__ from the parent.
+    So `autodoc_inherit_docstrings = False` will not do the job.
+
+    """
+    if what == "pydantic_model":
+        if hasattr(obj, "__init__") and obj.__init__.__doc__:
+            obj.__init__.__doc__ = None
+
 
 DOCS_SOURCE_DIR = os.path.dirname(__file__)
 sphinx.ext.apidoc.main([

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -9,6 +9,7 @@ GeoMetaMaker
    :maxdepth: 1
 
    basic_usage
+   metadata_resources
 
 .. toctree::
    :maxdepth: 1

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -16,6 +16,7 @@ GeoMetaMaker is developed by the `Natural Capital Project <https://naturalcapita
 .. toctree::
    :maxdepth: 1
 
+   installation
    basic_usage
    metadata_resources
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -4,7 +4,15 @@
    contain the root `toctree` directive.
 
 GeoMetaMaker
-========================================
+============
+
+Release: |release|
+
+GeoMetaMaker is a Python library for creating human and machine-readable
+metadata for geospatial, tabular, and other data formats.
+
+GeoMetaMaker is developed by the `Natural Capital Project <https://naturalcapitalproject.stanford.edu>`_.
+
 .. toctree::
    :maxdepth: 1
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -5,6 +5,10 @@
 
 GeoMetaMaker
 ========================================
+.. toctree::
+   :maxdepth: 1
+
+   basic_usage
 
 .. toctree::
    :maxdepth: 1

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -1,0 +1,25 @@
+Installation
+============
+
+Suggested Method: ``conda-forge``
+---------------------------------
+
+The easiest way to install ``geometamaker`` is using the
+`conda <https://docs.conda.io/en/latest/miniconda.html>`_ or
+`mamba <https://mamba.readthedocs.io/en/latest/installation.html>`_ package managers::
+
+    mamba install -c conda-forge geometamaker
+
+If you prefer to use ``conda``, the command is otherwise the same::
+
+    conda install -c conda-forge geometamaker
+
+Dependencies
+------------
+
+Dependencies for ``geometamaker`` are listed in ``requirements.txt`` and
+included here for your reference.  Your package manager should, under most
+circumstances, handle the dependency resolution for you.
+
+.. include:: ../../requirements.txt
+    :literal:

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -18,7 +18,7 @@ Dependencies
 ------------
 
 Dependencies for ``geometamaker`` are listed in ``requirements.txt`` and
-included here for your reference.  Your package manager should, under most
+included here for your reference. Your package manager should, under most
 circumstances, handle the dependency resolution for you.
 
 .. include:: ../../requirements.txt

--- a/docs/source/metadata_resources.rst
+++ b/docs/source/metadata_resources.rst
@@ -1,0 +1,10 @@
+Metadata Resource Models
+========================
+.. toctree::
+   :maxdepth: 1
+
+   raster_resource
+   vector_resource
+   table_resource
+   archive_resource
+   profile

--- a/docs/source/profile.rst
+++ b/docs/source/profile.rst
@@ -1,0 +1,6 @@
+Profile
+=======
+.. autopydantic_model:: geometamaker.models.Profile
+    :inherited-members: BaseModel
+    :model-show-json: True
+    :no-index:

--- a/docs/source/raster_resource.rst
+++ b/docs/source/raster_resource.rst
@@ -1,0 +1,6 @@
+Raster Resource
+===============
+.. autopydantic_model:: geometamaker.models.RasterResource
+    :inherited-members: BaseModel
+    :model-show-json: True
+    :no-index:

--- a/docs/source/table_resource.rst
+++ b/docs/source/table_resource.rst
@@ -1,0 +1,6 @@
+Table Resource
+==============
+.. autopydantic_model:: geometamaker.models.TableResource
+    :inherited-members: BaseModel
+    :model-show-json: True
+    :no-index:

--- a/docs/source/vector_resource.rst
+++ b/docs/source/vector_resource.rst
@@ -1,0 +1,6 @@
+Vector Resource
+===============
+.. autopydantic_model:: geometamaker.models.VectorResource
+    :inherited-members: BaseModel
+    :model-show-json: True
+    :no-index:

--- a/src/geometamaker/models.py
+++ b/src/geometamaker/models.py
@@ -19,7 +19,9 @@ LOGGER = logging.getLogger(__name__)
 class Parent(BaseModel):
     """Parent class on which to configure validation."""
 
-    model_config = ConfigDict(validate_assignment=True, extra='forbid')
+    model_config = ConfigDict(validate_assignment=True,
+                              extra='forbid',
+                              use_attribute_docstrings=True)
 
 
 # dataclass allows positional args, BaseModel does not.
@@ -95,6 +97,7 @@ class BandSchema(Parent):
     description: str = ''
     title: str = ''
     units: str = ''
+    """unit of measurement for the pixel values."""
 
 
 class RasterSchema(Parent):

--- a/src/geometamaker/models.py
+++ b/src/geometamaker/models.py
@@ -72,9 +72,9 @@ class FieldSchema(Parent):
 
     # https://datapackage.org/standard/table-schema/
     name: str
-    """The name of the field being described. Do not edit."""
+    """The name used to uniquely identify the field."""
     type: str
-    """Datatype of the content of the field. Do not edit."""
+    """Datatype of the content of the field."""
     description: str = ''
     """A description of the field."""
     title: str = ''
@@ -125,13 +125,9 @@ class RasterSchema(Parent):
     bands: List[BandSchema]
     """A list of ``BandSchema`` objects."""
     pixel_size: list
-    """The width and height of a pixel measured in ``SpatialSchema.crs_units``.
-
-    Do not edit."""
+    """The width and height of a pixel measured in ``SpatialSchema.crs_units``."""
     raster_size: Union[dict, list]
-    """The width and height of the raster measured in number of pixels.
-
-    Do not edit."""
+    """The width and height of the raster measured in number of pixels."""
 
     def model_post_init(self, __context):
         # Migrate from previous model where we stored this as a list
@@ -143,10 +139,10 @@ class RasterSchema(Parent):
 class BaseMetadata(Parent):
     """A class for the things shared by Resource and Profile."""
 
-    # These default to None in order to facilitate the logic
-    # in ``replace`` where we only replace values that are not None.
     contact: Union[ContactSchema, None] = Field(default_factory=ContactSchema)
+    """Contact information for the data author."""
     license: Union[LicenseSchema, None] = Field(default_factory=LicenseSchema)
+    """Data license information."""
 
     def set_contact(self, organization=None, individual_name=None,
                     position_name=None, email=None):
@@ -244,9 +240,11 @@ class Profile(BaseMetadata):
     """
 
     # For a Profile, default these to None so that they do not replace
-    # values in a Resource
+    # values in a Resource during ``BaseMetadata.replace``.
     contact: Union[ContactSchema, None] = None
+    """Contact information for the data author."""
     license: Union[LicenseSchema, None] = None
+    """Data license information."""
 
     @classmethod
     def load(cls, filepath):
@@ -295,30 +293,46 @@ class Resource(BaseMetadata):
 
     # These are populated geometamaker.describe()
     bytes: int = 0
+    """File size of the resource in bytes."""
     encoding: str = ''
+    """File encoding of the resource."""
     format: str = ''
+    """File format of the resource."""
     uid: str = ''
+    """Unique identifier for the resource."""
     path: str = ''
+    """Path to the resource being described."""
     scheme: str = ''
+    """File protocol for opening the resource."""
     type: str = ''
+    """The type of resource being described."""
     last_modified: str = ''
-    # DataPackage includes `sources` as a list of source files
-    # with some amount of metadata for each item. For our
-    # use-case, I think a list of filenames is good enough.
+    """Last modified time of the file at ``path``."""
     sources: list = Field(default_factory=list)
+    """A list of files which comprise the dataset or resource."""
 
     # These are not populated by geometamaker.describe(),
     # and should have setters & getters
     citation: str = ''
+    """A citation for the resource."""
     description: str = ''
+    """A text description of the resource."""
     doi: str = ''
+    """A digital object identifier for the resource."""
     edition: str = ''
+    """A string representing the edition, or version, of the resource."""
     keywords: list = Field(default_factory=list)
+    """A list of keywords that describe the subject-matter of the resource."""
     lineage: str = ''
+    """A text description of how the resource was created."""
     placenames: list = Field(default_factory=list)
+    """A list of geographic places associated with the resource."""
     purpose: str = ''
+    """The author's stated purpose for the resource."""
     title: str = ''
+    """The title of the resource."""
     url: str = ''
+    """A URL where the resource is available."""
 
     def model_post_init(self, __context):
         self.metadata_path = f'{self.path}.yml'
@@ -564,6 +578,7 @@ class TableResource(Resource):
     """Class for metadata for a table resource."""
 
     data_model: TableSchema = Field(default_factory=TableSchema)
+    """A ``models.TableSchema`` object for describing fields."""
 
     def _get_field(self, name):
         """Get an attribute by its name property.
@@ -631,20 +646,25 @@ class ArchiveResource(Resource):
     """Class for metadata for an archive resource."""
 
     compression: str
+    """The compression method used to create the archive."""
 
 
 class VectorResource(TableResource):
     """Class for metadata for a vector resource."""
 
     n_features: int
+    """Number of features in the layer."""
     spatial: SpatialSchema
+    """An object for describing spatial properties of a GDAL dataset."""
 
 
 class RasterResource(Resource):
     """Class for metadata for a raster resource."""
 
     data_model: RasterSchema
+    """An object for describing raster properties and bands."""
     spatial: SpatialSchema
+    """An object for describing spatial properties of a GDAL dataset."""
 
     def set_band_description(self, band_number, title=None,
                              description=None, units=None):

--- a/src/geometamaker/models.py
+++ b/src/geometamaker/models.py
@@ -104,13 +104,13 @@ class BandSchema(Parent):
     """Class for metadata for a raster band."""
 
     index: int
-    """The index of the band of a GDAL raster, starting at 1. Do not edit."""
+    """The index of the band of a GDAL raster, starting at 1."""
     gdal_type: str
-    """The GDAL data type of the band. Do not edit."""
+    """The GDAL data type of the band."""
     numpy_type: str
-    """The numpy data type of the band. Do not edit."""
+    """The numpy data type of the band."""
     nodata: Union[int, float, None]
-    """The pixel value that represents no data in the band. Do not edit."""
+    """The pixel value that represents no data in the band."""
     description: str = ''
     """A description of the band."""
     title: str = ''

--- a/src/geometamaker/models.py
+++ b/src/geometamaker/models.py
@@ -41,12 +41,15 @@ class SpatialSchema(Parent):
     """Class for keeping track of spatial info."""
 
     bounding_box: BoundingBox
+    """Spatial extent [xmin, ymin, xmax, ymax]."""
     crs: str
+    """Coordinate Reference System."""
     crs_units: str
+    """Units of measure for coordinates in the CRS."""
 
 
 class ContactSchema(Parent):
-    """Class for keeping track of contact info."""
+    """Class for storing contact information of data author."""
 
     email: str = ''
     organization: str = ''
@@ -55,15 +58,13 @@ class ContactSchema(Parent):
 
 
 class LicenseSchema(Parent):
-    """Class for storing license info."""
+    """Class for storing data license information."""
 
-    # https://datapackage.org/profiles/2.0/dataresource.json
-    # This profile also includes `name`, described as:
-    # "MUST be an Open Definition license identifier",
-    # see http://licenses.opendefinition.org/"
-    # I don't think that's useful to us yet.
+    # Loosely follows https://datapackage.org/profiles/2.0/dataresource.json
     path: str = ''
+    """URL that describes the license."""
     title: str = ''
+    """Name of a license, such as one from http://licenses.opendefinition.org/"""
 
 
 class FieldSchema(Parent):
@@ -71,10 +72,15 @@ class FieldSchema(Parent):
 
     # https://datapackage.org/standard/table-schema/
     name: str
+    """The name of the field being described. Do not edit."""
     type: str
+    """Datatype of the content of the field. Do not edit."""
     description: str = ''
+    """A description of the field."""
     title: str = ''
+    """A human-readable title for the field."""
     units: str = ''
+    """Unit of measurement for values in the field."""
 
 
 class TableSchema(Parent):
@@ -82,30 +88,50 @@ class TableSchema(Parent):
 
     # https://datapackage.org/standard/table-schema/
     fields: List[FieldSchema]
+    """A list of ``FieldSchema`` objects."""
     missingValues: list = Field(default_factory=list)
+    """A list of values that represent missing data."""
     primaryKey: list = Field(default_factory=list)
+    """A field or list of fields that uniquely identifies each row in the table."""
     foreignKeys: list = Field(default_factory=list)
+    """A field or list of fields that can be used to join another table.
+
+    See https://datapackage.org/standard/table-schema/#foreignKeys
+    """
 
 
 class BandSchema(Parent):
     """Class for metadata for a raster band."""
 
     index: int
+    """The index of the band of a GDAL raster, starting at 1. Do not edit."""
     gdal_type: str
+    """The GDAL data type of the band. Do not edit."""
     numpy_type: str
+    """The numpy data type of the band. Do not edit."""
     nodata: Union[int, float, None]
+    """The pixel value that represents no data in the band. Do not edit."""
     description: str = ''
+    """A description of the band."""
     title: str = ''
+    """A human-readable title for the band."""
     units: str = ''
-    """unit of measurement for the pixel values."""
+    """Unit of measurement for the pixel values."""
 
 
 class RasterSchema(Parent):
     """Class for metadata for raster bands."""
 
     bands: List[BandSchema]
+    """A list of ``BandSchema`` objects."""
     pixel_size: list
+    """The width and height of a pixel measured in ``SpatialSchema.crs_units``.
+
+    Do not edit."""
     raster_size: Union[dict, list]
+    """The width and height of the raster measured in number of pixels.
+
+    Do not edit."""
 
     def model_post_init(self, __context):
         # Migrate from previous model where we stored this as a list

--- a/src/geometamaker/models.py
+++ b/src/geometamaker/models.py
@@ -570,9 +570,6 @@ class Resource(BaseMetadata):
             file.write(utils.yaml_dump(
                 self.model_dump(exclude=['metadata_path'])))
 
-    def to_string(self):
-        pass
-
 
 class TableResource(Resource):
     """Class for metadata for a table resource."""

--- a/src/geometamaker/models.py
+++ b/src/geometamaker/models.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 import logging
 import os
 import warnings
-from typing import List, Union
+from typing import Union
 
 import fsspec
 import yaml
@@ -87,13 +87,13 @@ class TableSchema(Parent):
     """Class for metadata for tables."""
 
     # https://datapackage.org/standard/table-schema/
-    fields: List[FieldSchema]
+    fields: list[FieldSchema]
     """A list of ``FieldSchema`` objects."""
     missingValues: list = Field(default_factory=list)
     """A list of values that represent missing data."""
-    primaryKey: list = Field(default_factory=list)
+    primaryKey: list[str] = Field(default_factory=list)
     """A field or list of fields that uniquely identifies each row in the table."""
-    foreignKeys: list = Field(default_factory=list)
+    foreignKeys: list[str] = Field(default_factory=list)
     """A field or list of fields that can be used to join another table.
 
     See https://datapackage.org/standard/table-schema/#foreignKeys
@@ -122,9 +122,9 @@ class BandSchema(Parent):
 class RasterSchema(Parent):
     """Class for metadata for raster bands."""
 
-    bands: List[BandSchema]
+    bands: list[BandSchema]
     """A list of ``BandSchema`` objects."""
-    pixel_size: list
+    pixel_size: tuple[Union[int, float], Union[int, float]]
     """The width and height of a pixel measured in ``SpatialSchema.crs_units``."""
     raster_size: Union[dict, list]
     """The width and height of the raster measured in number of pixels."""
@@ -291,7 +291,7 @@ class Resource(BaseMetadata):
     geometamaker_version: str = ''
     metadata_path: str = ''
 
-    # These are populated geometamaker.describe()
+    # These are populated by geometamaker.describe()
     bytes: int = 0
     """File size of the resource in bytes."""
     encoding: str = ''
@@ -308,7 +308,7 @@ class Resource(BaseMetadata):
     """The type of resource being described."""
     last_modified: str = ''
     """Last modified time of the file at ``path``."""
-    sources: list = Field(default_factory=list)
+    sources: list[str] = Field(default_factory=list)
     """A list of files which comprise the dataset or resource."""
 
     # These are not populated by geometamaker.describe(),
@@ -321,11 +321,11 @@ class Resource(BaseMetadata):
     """A digital object identifier for the resource."""
     edition: str = ''
     """A string representing the edition, or version, of the resource."""
-    keywords: list = Field(default_factory=list)
+    keywords: list[str] = Field(default_factory=list)
     """A list of keywords that describe the subject-matter of the resource."""
     lineage: str = ''
     """A text description of how the resource was created."""
-    placenames: list = Field(default_factory=list)
+    placenames: list[str] = Field(default_factory=list)
     """A list of geographic places associated with the resource."""
     purpose: str = ''
     """The author's stated purpose for the resource."""

--- a/tests/test_geometamaker.py
+++ b/tests/test_geometamaker.py
@@ -94,9 +94,13 @@ class GeometamakerTests(unittest.TestCase):
     def setUp(self):
         """Override setUp function to create temp workspace directory."""
         self.workspace_dir = tempfile.mkdtemp()
+        self.patcher = patch('geometamaker.config.platformdirs.user_config_dir')
+        self.mock_user_config_dir = self.patcher.start()
+        self.mock_user_config_dir.return_value = self.workspace_dir
 
     def tearDown(self):
         """Override tearDown function to remove temporary directory."""
+        self.patcher.stop()
         shutil.rmtree(self.workspace_dir)
 
     def test_file_does_not_exist(self):
@@ -558,6 +562,7 @@ class GeometamakerTests(unittest.TestCase):
         resource.set_contact(individual_name='alice')
         resource.write()
 
+        # Describe the same dataset, with new profile info
         profile = geometamaker.Profile()
         profile.set_contact(individual_name='bob')
         new_resource = geometamaker.describe(datasource_path, profile=profile)
@@ -566,6 +571,24 @@ class GeometamakerTests(unittest.TestCase):
             new_resource.get_title(), title)
         self.assertEqual(
             new_resource.contact.individual_name, 'bob')
+
+    def test_preexisting_metadata_profile_not_overwritten(self):
+        """Test doc with contact info is not overwritten by blank profile."""
+        import geometamaker
+
+        datasource_path = os.path.join(self.workspace_dir, 'raster.tif')
+        create_raster(numpy.int16, datasource_path)
+        resource = geometamaker.describe(datasource_path)
+        resource.set_contact(individual_name='alice')
+        resource.write()
+
+        # mocking should mean there is no config, but just to be certain
+        config = geometamaker.Config()
+        config.delete()
+
+        new_resource = geometamaker.describe(datasource_path)
+        self.assertEqual(
+            new_resource.contact.individual_name, 'alice')
 
     def test_preexisting_incompatible_doc(self):
         """Test when yaml file not created by geometamaker already exists."""


### PR DESCRIPTION
This PR improves API documentation. API docs now include,

* A Basic Usage page currently based on content in the readme
* Pages for each of the main user-facing data models, which now include docstrings for attributes
* Better-formatted docs for Pydantic classes.

Fixes #67 