### PR TITLE
Add support for tar gzip files

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -5,6 +5,8 @@ Release History
 ---------------------
 * Allow CLI to ``describe`` remote datasets.
   https://github.com/natcap/geometamaker/issues/78
+* Add support for describing tar gzip files in the same manner as zip
+  archives. https://github.com/natcap/geometamaker/issues/26
 
 0.1.2 (2025-02-05)
 ------------------

--- a/src/geometamaker/geometamaker.py
+++ b/src/geometamaker/geometamaker.py
@@ -125,9 +125,9 @@ def detect_file_type(filepath, scheme):
     # Frictionless supports a wide range of formats. The quickest way to
     # determine if a file is recognized as a table or archive is to call list.
     info = frictionless.list(filepath)[0]
-    # Frictionless doesn't recognize .tgz compression, so check format
     if info.type == 'table':
         return 'table'
+    # Frictionless doesn't recognize .tgz compression (but does recognize .tar.gz)
     if info.compression or info.format == "tgz":
         return 'archive'
     # GDAL considers CSV a vector, so check against frictionless first.

--- a/src/geometamaker/geometamaker.py
+++ b/src/geometamaker/geometamaker.py
@@ -229,7 +229,7 @@ def describe_archive(source_dataset_path, scheme):
     # it does not include all the files contained in the zip
     description.pop('innerpath', None)
 
-    if zipfile.is_zipfile(source_dataset_path):
+    if description.get("compression") == "zip":
         file_list = _list_zip_contents(source_dataset_path)
 
     elif tarfile.is_tarfile(source_dataset_path):

--- a/src/geometamaker/geometamaker.py
+++ b/src/geometamaker/geometamaker.py
@@ -337,7 +337,7 @@ def describe_table(source_dataset_path, scheme):
     return description
 
 
-DESCRIBE_FUNCS = {
+DESRCIBE_FUNCS = {
     'archive': describe_archive,
     'table': describe_table,
     'vector': describe_vector,
@@ -388,56 +388,48 @@ def describe(source_dataset_path, profile=None):
             f'Cannot describe {source_dataset_path}. {protocol} '
             f'is not one of the suppored file protocols: {PROTOCOLS}')
     resource_type = detect_file_type(source_dataset_path, protocol)
-    description = DESCRIBE_FUNCS[resource_type](
+    description = DESRCIBE_FUNCS[resource_type](
         source_dataset_path, protocol)
     description['type'] = resource_type
+    resource = RESOURCE_MODELS[resource_type](**description)
 
     # Load existing metadata file
     try:
+        # For the data model, use heuristic to decide if the new resource
+        # should inherit values from the existing resource.
+        # After that, take all non-empty values from the new resource
+        # and update the existing resource.
         existing_resource = RESOURCE_MODELS[resource_type].load(metadata_path)
-        if 'data_model' in description:
-            if isinstance(description['data_model'], models.RasterSchema):
-                # If existing band metadata still matches data_model of the file
-                # carry over existing metadata because it could include
-                # human-defined properties.
-                new_bands = []
-                for band in description['data_model'].bands:
-                    try:
-                        eband = existing_resource.get_band_description(band.index)
-                        # TODO: rewrite this as __eq__ of BandSchema?
-                        if (band.numpy_type, band.gdal_type, band.nodata) == (
-                                eband.numpy_type, eband.gdal_type, eband.nodata):
-                            updated_dict = band.model_dump() | eband.model_dump()
-                            band = models.BandSchema(**updated_dict)
-                    except IndexError:
-                        pass
-                    new_bands.append(band)
-                description['data_model'].bands = new_bands
-            if isinstance(description['data_model'], models.TableSchema):
-                # If existing field metadata still matches data_model of the file
-                # carry over existing metadata because it could include
-                # human-defined properties.
-                new_fields = []
-                for field in description['data_model'].fields:
-                    try:
-                        efield = existing_resource.get_field_description(
-                            field.name)
-                        # TODO: rewrite this as __eq__ of FieldSchema?
-                        if field.type == efield.type:
-                            updated_dict = field.model_dump() | efield.model_dump()
-                            field = models.FieldSchema(**updated_dict)
-                    except KeyError:
-                        pass
-                    new_fields.append(field)
-                description['data_model'].fields = new_fields
-        # overwrite properties that are intrinsic to the dataset
-        updated_dict = existing_resource.model_dump() | description
-        resource = RESOURCE_MODELS[resource_type](**updated_dict)
+        if resource_type == 'raster':
+            for band in resource.data_model.bands:
+                try:
+                    eband = existing_resource.get_band_description(band.index)
+                except IndexError:
+                    continue
+                if (band.numpy_type, band.gdal_type, band.nodata) == (
+                        eband.numpy_type, eband.gdal_type, eband.nodata):
+                    resource.set_band_description(
+                        band.index,
+                        title=eband.title,
+                        description=eband.description,
+                        units=eband.units)
+        if resource_type in ('vector', 'table'):
+            for field in resource.data_model.fields:
+                try:
+                    efield = existing_resource.get_field_description(field.name)
+                except KeyError:
+                    continue
+                if field.type == efield.type:
+                    resource.set_field_description(
+                        field.name,
+                        title=efield.title,
+                        description=efield.description,
+                        units=efield.units)
+        resource = existing_resource.replace(resource)
 
     # Common path: metadata file does not already exist
-    # Or less common, ValueError if it exists but is incompatible
     except FileNotFoundError:
-        resource = RESOURCE_MODELS[resource_type](**description)
+        pass
 
     resource = resource.replace(user_profile)
     return resource

--- a/src/geometamaker/geometamaker.py
+++ b/src/geometamaker/geometamaker.py
@@ -337,7 +337,7 @@ def describe_table(source_dataset_path, scheme):
     return description
 
 
-DESRCIBE_FUNCS = {
+DESCRIBE_FUNCS = {
     'archive': describe_archive,
     'table': describe_table,
     'vector': describe_vector,
@@ -388,7 +388,7 @@ def describe(source_dataset_path, profile=None):
             f'Cannot describe {source_dataset_path}. {protocol} '
             f'is not one of the suppored file protocols: {PROTOCOLS}')
     resource_type = detect_file_type(source_dataset_path, protocol)
-    description = DESRCIBE_FUNCS[resource_type](
+    description = DESCRIBE_FUNCS[resource_type](
         source_dataset_path, protocol)
     description['type'] = resource_type
     resource = RESOURCE_MODELS[resource_type](**description)

--- a/src/geometamaker/geometamaker.py
+++ b/src/geometamaker/geometamaker.py
@@ -128,7 +128,7 @@ def detect_file_type(filepath, scheme):
     info = frictionless.list(filepath)[0]
     if info.type == 'table':
         return 'table'
-    if info.compression or filepath.endswith((".tgz", ".tar.gz", ".tar")):
+    if info.compression or tarfile.is_tarfile(filepath):
         return 'archive'
     # GDAL considers CSV a vector, so check against frictionless first.
     try:
@@ -236,7 +236,7 @@ def describe_archive(source_dataset_path, scheme):
         file_list = _list_tgz_contents(source_dataset_path)
         # 'compression' attr not auto-added by frictionless.describe for tgz
         if source_dataset_path.endswith((".tgz", ".tar.gz")):
-            description["compression"] = "tar gz"
+            description["compression"] = "tar gzip"
     else:
         raise ValueError(f"Unsupported archive format: {source_dataset_path}")
 

--- a/src/geometamaker/geometamaker.py
+++ b/src/geometamaker/geometamaker.py
@@ -125,9 +125,10 @@ def detect_file_type(filepath, scheme):
     # Frictionless supports a wide range of formats. The quickest way to
     # determine if a file is recognized as a table or archive is to call list.
     info = frictionless.list(filepath)[0]
+    # Frictionless doesn't recognize .tgz compression, so check format
     if info.type == 'table':
         return 'table'
-    if info.format in ["zip", "tar", "tgz"]:
+    if info.compression or info.format == "tgz":
         return 'archive'
     # GDAL considers CSV a vector, so check against frictionless first.
     try:

--- a/src/geometamaker/geometamaker.py
+++ b/src/geometamaker/geometamaker.py
@@ -127,8 +127,8 @@ def detect_file_type(filepath, scheme):
     info = frictionless.list(filepath)[0]
     if info.type == 'table':
         return 'table'
-    # Frictionless doesn't recognize .tgz same as .tar.gz, so check w/ tarfile
-    if info.compression or tarfile.is_tarfile(filepath):
+    # Frictionless doesn't recognize .tgz compression, so check format
+    if info.compression or info.format == "tgz":
         return 'archive'
     # GDAL considers CSV a vector, so check against frictionless first.
     try:

--- a/src/geometamaker/models.py
+++ b/src/geometamaker/models.py
@@ -654,7 +654,7 @@ class TableResource(Resource):
 class ArchiveResource(Resource):
     """Class for metadata for an archive resource."""
 
-    compression: str
+    compression: str = ''
     """The compression method used to create the archive."""
 
 

--- a/tests/test_geometamaker.py
+++ b/tests/test_geometamaker.py
@@ -23,6 +23,7 @@ REGRESSION_DATA = os.path.join(
 
 # A remote file we can use for testing
 REMOTE_FILEPATH = 'https://storage.googleapis.com/releases.naturalcapitalproject.org/invest/3.14.2/data/CoastalBlueCarbon.zip'
+REMOTE_TARGZ = 'https://storage.googleapis.com/releases.naturalcapitalproject.org/invest/3.15.0/natcap_invest-3.15.0.tar.gz'
 
 # This is the complete list of types, but some are
 # exceedingly rare and do not match easily to python types
@@ -335,7 +336,7 @@ class GeometamakerTests(unittest.TestCase):
         resource = geometamaker.describe(tgz_path)
         self.assertEqual(resource.sources, [os.path.basename(raster_path),
                                             os.path.basename(vector_path)])
-        self.assertEqual(resource.compression, "tar gzip")
+        self.assertEqual(resource.compression, "gz")
 
     def test_set_description(self):
         """Test set and get a description for a resource."""
@@ -652,6 +653,14 @@ class GeometamakerTests(unittest.TestCase):
         filepath = REMOTE_FILEPATH
         resource = geometamaker.describe(filepath)
         self.assertEqual(resource.path, filepath)
+
+    def test_describe_remote_targz(self):
+        """Test describe on a .tar.gz file at a public url."""
+        import geometamaker
+
+        filepath = REMOTE_TARGZ
+        resource = geometamaker.describe(filepath)
+        self.assertEqual(resource.path, REMOTE_TARGZ)
 
     def test_validate_valid_document(self):
         """Test validate function returns nothing."""

--- a/tests/test_geometamaker.py
+++ b/tests/test_geometamaker.py
@@ -23,7 +23,6 @@ REGRESSION_DATA = os.path.join(
 
 # A remote file we can use for testing
 REMOTE_FILEPATH = 'https://storage.googleapis.com/releases.naturalcapitalproject.org/invest/3.14.2/data/CoastalBlueCarbon.zip'
-REMOTE_TARGZ = 'https://storage.googleapis.com/releases.naturalcapitalproject.org/invest/3.15.0/natcap_invest-3.15.0.tar.gz'
 
 # This is the complete list of types, but some are
 # exceedingly rare and do not match easily to python types
@@ -653,14 +652,6 @@ class GeometamakerTests(unittest.TestCase):
         filepath = REMOTE_FILEPATH
         resource = geometamaker.describe(filepath)
         self.assertEqual(resource.path, filepath)
-
-    def test_describe_remote_targz(self):
-        """Test describe on a .tar.gz file at a public url."""
-        import geometamaker
-
-        filepath = REMOTE_TARGZ
-        resource = geometamaker.describe(filepath)
-        self.assertEqual(resource.path, REMOTE_TARGZ)
 
     def test_validate_valid_document(self):
         """Test validate function returns nothing."""

--- a/tests/test_geometamaker.py
+++ b/tests/test_geometamaker.py
@@ -317,6 +317,26 @@ class GeometamakerTests(unittest.TestCase):
         resource = geometamaker.describe(zip_filepath)
         self.assertEqual(resource.sources, [a_name, b_name.replace('\\', '/')])
 
+    def test_describe_tgz(self):
+        """Test metadata for .tgz includes correct sources and compression"""
+        import tarfile
+        import geometamaker
+
+        tgz_path = os.path.join(self.workspace_dir, "test_tgz.tgz")
+        raster_path = os.path.join(self.workspace_dir, "temp.tif")
+        vector_path = os.path.join(self.workspace_dir, "temp.geojson")
+        create_raster(numpy.int8, raster_path)
+        create_vector(vector_path)
+
+        with tarfile.open(tgz_path, 'w:gz') as tar:
+            for file_path in [raster_path, vector_path]:
+                tar.add(file_path, arcname=os.path.basename(file_path))
+
+        resource = geometamaker.describe(tgz_path)
+        self.assertEqual(resource.sources, [os.path.basename(raster_path),
+                                            os.path.basename(vector_path)])
+        self.assertEqual(resource.compression, "tar gzip")
+
     def test_set_description(self):
         """Test set and get a description for a resource."""
 


### PR DESCRIPTION
This feature allows a user to `describe` `.tar` and `.tgz` (and `.tar.gz`) archives (essentially, list the contents of the archive) without extracting them. This PR is similar to PR #42.

Note that this feature does _not_ address use-case 1 in #26, i.e. create
> metadata for single files that happen to be zips, tgz, etc



Fixes #26