### PR TITLE
Feature: create metadata for collections/directories

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -16,6 +16,12 @@ Unreleased Changes
   calling ``describe`` on the vector dataset. GeoMetaMaker still only
   supports describing metadata for the first layer in a vector dataset.
   https://github.com/natcap/geometamaker/issues/28
+* Add support for describing folders as collections, generating a single
+  metadata file listing contained files along with their descriptions and
+  metadata. https://github.com/natcap/geometamaker/issues/66
+* ``describe_dir`` has been renamed to ``describe_all`` and the parameter
+  ``recursive`` has been replaced with ``depth`` to allow for more
+  fine-grained control.
 
 0.1.2 (2025-02-05)
 ------------------

--- a/README.md
+++ b/README.md
@@ -63,6 +63,9 @@ to add these values manually by editing the
 `watershed_gura.shp.yml` file in a text editor.
 
 ### Creating metadata for a batch of files:
+Users can optionally specify `depth` to limit the number of subdirectory 
+levels to traverse when walking through a directory and creating metadata 
+for the supported files.
 
 #### Python
 ```python
@@ -71,12 +74,27 @@ import os
 import geometamaker
 
 data_dir = 'C:/Users/dmf/projects/invest/data/invest-sample-data'
-geometamaker.describe_dir(data_dir, recursive=True)
+geometamaker.describe_all(data_dir, depth=3)
 ```
 
 #### CLI
 ```
-geometamaker describe -r data/invest-sample-data
+geometamaker describe -d 3 data/invest-sample-data
+```
+
+### Creating metadata for a collection of files
+Users can create a single metadata document to describe a directory of 
+files, with the option of excluding some files using a regular expression.
+
+#### Python
+```python
+import geometamaker
+
+collection_path = 'invest/data/invest-sample-data'
+metadata = geometamaker.describe_collection(collection_path,
+                                            depth=2,
+                                            exclude_regex=r'.*\.json$')
+metadata.write()
 ```
 
 ### Validating a metadata document:

--- a/README.md
+++ b/README.md
@@ -69,8 +69,6 @@ for the supported files.
 
 #### Python
 ```python
-import os
-
 import geometamaker
 
 data_dir = 'C:/Users/dmf/projects/invest/data/invest-sample-data'
@@ -82,7 +80,7 @@ geometamaker.describe_all(data_dir, depth=3)
 geometamaker describe -d 3 data/invest-sample-data
 ```
 
-### Creating metadata for a collection of files
+### Creating metadata for a collection of files:
 Users can create a single metadata document to describe a directory of 
 files, with the option of excluding some files using a regular expression.
 
@@ -115,7 +113,7 @@ print(error)
 geometamaker validate data/watershed_gura.shp.yml
 ```
 
-### Validating all metadata documents in a directory
+### Validating all metadata documents in a directory:
 
 ##### Python
 ```python
@@ -144,8 +142,6 @@ during runtime, which takes precedence over a profile in the config file.
 
 #### Create & apply a Profile at runtime
 ```python
-import os
-
 import geometamaker
 from geometamaker import models
 
@@ -169,8 +165,6 @@ resource = geometamaker.describe(data_path, profile=profile)
 
 ##### Python
 ```python
-import os
-
 import geometamaker
 from geometamaker import models
 

--- a/docs/source/collection_resource.rst
+++ b/docs/source/collection_resource.rst
@@ -1,0 +1,6 @@
+Collection Resource
+===============
+.. autopydantic_model:: geometamaker.models.CollectionResource
+    :inherited-members: BaseModel
+    :model-show-json: True
+    :no-index:

--- a/docs/source/metadata_resources.rst
+++ b/docs/source/metadata_resources.rst
@@ -7,4 +7,5 @@ Metadata Resource Models
    vector_resource
    table_resource
    archive_resource
+   collection_resource
    profile

--- a/src/geometamaker/__init__.py
+++ b/src/geometamaker/__init__.py
@@ -1,7 +1,8 @@
 import importlib.metadata
 
 from .geometamaker import describe
-from .geometamaker import describe_dir
+from .geometamaker import describe_all
+from .geometamaker import describe_collection
 from .geometamaker import validate
 from .geometamaker import validate_dir
 from .config import Config
@@ -10,4 +11,4 @@ from .models import Profile
 
 __version__ = importlib.metadata.version('geometamaker')
 
-__all__ = ('describe', 'describe_dir', 'validate', 'validate_dir', 'Config', 'Profile')
+__all__ = ('describe', 'describe_all', 'describe_collection', 'validate', 'validate_dir', 'Config', 'Profile')

--- a/src/geometamaker/cli.py
+++ b/src/geometamaker/cli.py
@@ -4,6 +4,7 @@ import sys
 
 import click
 import fsspec
+import numpy
 from pydantic import ValidationError
 
 import geometamaker
@@ -71,28 +72,28 @@ class _URL(click.ParamType):
 @click.argument('filepath',
                 type=_ParamUnion([click.Path(exists=True), _URL()],
                                  report_all_errors=False))
-@click.option('-r', '--recursive',
-              is_flag=True,
-              default=False,
-              help='if FILEPATH is a directory, describe files '
-                   'in all subdirectories')
+@click.option('-d', '--depth',
+              default=numpy.inf,
+              help='if FILEPATH is a directory, describe files in'
+                   'subdirectories up to depth. Defaults to to describing '
+                   'all files.')
 @click.option('-nw', '--no-write',
               is_flag=True,
               default=False,
               help='Dump metadata to stdout instead of to a .yml file. '
                    'This option is ignored if `filepath` is a directory')
-def describe(filepath, recursive, no_write):
+def describe(filepath, depth, no_write):
     if os.path.isdir(filepath):
         if no_write:
             click.echo('the -nw, or --no-write, flag is ignored when '
                        'describing all files in a directory.')
-        geometamaker.describe_dir(
-            filepath, recursive=recursive)
+        geometamaker.describe_all(
+            filepath, depth=depth)
     else:
         resource = geometamaker.describe(filepath)
         if no_write:
             click.echo(geometamaker.utils.yaml_dump(
-                resource.model_dump(exclude=['metadata_path'])))
+                resource._dump_for_write()))
         else:
             try:
                 resource.write()

--- a/src/geometamaker/cli.py
+++ b/src/geometamaker/cli.py
@@ -73,7 +73,7 @@ class _URL(click.ParamType):
                 type=_ParamUnion([click.Path(exists=True), _URL()],
                                  report_all_errors=False))
 @click.option('-d', '--depth',
-              default=numpy.inf,
+              default=numpy.iinfo(numpy.int16).max,
               help='if FILEPATH is a directory, describe files in'
                    'subdirectories up to depth. Defaults to to describing '
                    'all files.')

--- a/src/geometamaker/geometamaker.py
+++ b/src/geometamaker/geometamaker.py
@@ -706,7 +706,7 @@ def describe_all(directory, depth=1):
             filepath = f'{root}{ext}'
             try:
                 resource = describe(filepath)
-            except ValueError as error:
+            except (ValueError, frictionless.FrictionlessException) as error:
                 LOGGER.debug(error)
                 continue
             resource.write()

--- a/src/geometamaker/geometamaker.py
+++ b/src/geometamaker/geometamaker.py
@@ -401,14 +401,14 @@ def describe_table(source_dataset_path, scheme):
     return description
 
 
-def describe_collection(directory, depth=numpy.inf,
-                        exclude_regex=None, exclude_hidden=True,
-                        describe_files=False):
+def describe_collection(directory, depth=numpy.inf, exclude_regex=None,
+                        exclude_hidden=True, describe_files=False):
     """Create a single metadata document to describe a collection of files.
 
     Describe all the files within a directory as members of a "collection".
     The resulting metadata resource should include a list of all the files
-    included in the collection along with a description (or placeholder)
+    included in the collection along with a description and metadata filepath
+    (or placeholder).
 
     This is distinct from ``describe_all``, which
     creates individual metadata files for each supported file in a directory.

--- a/src/geometamaker/geometamaker.py
+++ b/src/geometamaker/geometamaker.py
@@ -108,8 +108,23 @@ def _wkt_to_epsg_units_string(wkt_string):
 
 
 def _list_files_with_depth(directory, depth, exclude_regex,
-                           exclude_hidden=True, use_relative=False):
-    """List files in directory up to depth"""
+                           exclude_hidden=True):
+    """List files in directory up to depth
+
+    Args:
+        directory (string): path to a directory
+        depth (int): maximum number of subdirectory levels to traverse when
+            walking through a directory. A value of 1 limits the walk to files
+            in the top-level ``directory`` only. A value of 2 allows
+            descending into immediate subdirectories, etc.
+        exclude_regex (str, optional): a regular expression to pattern-match
+            any files for which you do not want to create metadata.
+        exclude_hidden (bool, default True): whether to ignore hidden files
+
+    Returns:
+        list of relative filepaths in ``directory``
+
+    """
     directory = Path(directory).resolve()
     file_list = []
 
@@ -121,7 +136,7 @@ def _list_files_with_depth(directory, depth, exclude_regex,
         if exclude_hidden and (
                 any(part.startswith('.') for part in relative_path.parts)):
             continue
-        file_list.append(str(relative_path if use_relative else path))
+        file_list.append(str(relative_path))
 
     # remove excluded files based on regex
     if exclude_regex:
@@ -444,7 +459,7 @@ def describe_collection(directory, depth=numpy.iinfo(numpy.int16).max,
     directory = str(Path(directory).resolve())
 
     file_list = _list_files_with_depth(directory, depth, exclude_regex,
-                                       exclude_hidden, use_relative=True)
+                                       exclude_hidden)
 
     root_ext_map, root_list = _group_files_by_root(file_list)
 
@@ -709,7 +724,7 @@ def describe_all(directory, depth=numpy.iinfo(numpy.int16).max,
             # of these other files with the same root name
             extensions.difference_update(['.shx', '.sbn', '.sbx', '.prj', '.dbf', '.cpg'])
         for ext in extensions:
-            filepath = f'{root}{ext}'
+            filepath = os.path.join(directory, f'{root}{ext}')
             try:
                 resource = describe(filepath)
             except (ValueError, frictionless.FrictionlessException) as error:

--- a/src/geometamaker/geometamaker.py
+++ b/src/geometamaker/geometamaker.py
@@ -515,7 +515,6 @@ def describe_collection(directory, depth=numpy.iinfo(numpy.int16).max,
     # Add profile metadata
     config = Config()
     resource = resource.replace(config.profile)
-    resource.write()
 
     return resource
 

--- a/src/geometamaker/geometamaker.py
+++ b/src/geometamaker/geometamaker.py
@@ -438,23 +438,22 @@ def describe_collection(directory, depth=numpy.iinfo(numpy.int16).max,
 
     Args:
         directory (str): path to collection
-        depth (int): maximum number of subdirectory levels to traverse when
-            walking through ``directory`` to find files included in the
-            collection. A value of 1 limits the walk to files in the top-level
-            ``directory`` only. A value of 2 allows descending into immediate
-            subdirectories, etc. By default, will include all files in all
-            subdirectories in the collection.
+        depth (int, optional): maximum number of subdirectory levels to
+            traverse when walking through ``directory`` to find files included
+            in the collection. A value of 1 limits the walk to files in the
+            top-level ``directory`` only. A value of 2 allows descending into
+            immediate subdirectories, etc. All files in all subdirectories in
+            the collection will be included by default.
         exclude_regex (str, optional): a regular expression to pattern-match
             any files you do not want included in the output metadata yml.
         exclude_hidden (bool, default True): whether to exclude hidden files
             (files that start with ".").
-        describe_files (bool, default False): whether to ``describe_all`` and
-            create individual metadata files for each supported resource in the
-            collection. Using this will also add an additional attribute
-            ``collection`` (which refers back to the collection metadata yaml)
-            to any sidecar metadata created.
+        describe_files (bool, default False): whether to ``describe`` all
+            files, i.e., create individual metadata files for each supported
+            resource in the collection.
 
-    Returns: Collection metadata
+    Returns:
+        Collection metadata
     """
     directory = str(Path(directory).resolve())
 

--- a/src/geometamaker/geometamaker.py
+++ b/src/geometamaker/geometamaker.py
@@ -113,8 +113,8 @@ def _list_files_with_depth(directory, depth=1, exclude_hidden=True):
     file_list = []
 
     for path in directory.rglob("*"):
-        # relative_path = path.relative_to(directory)
-        current_depth = len(path.parts)
+        relative_path = path.relative_to(directory)
+        current_depth = len(relative_path.parts)
         if current_depth > depth:
             continue
         if exclude_hidden and any(part.startswith('.') for part in path.parts):
@@ -401,7 +401,7 @@ def describe_table(source_dataset_path, scheme):
     return description
 
 
-def describe_collection(directory, depth=1, target_yml_path=None,
+def describe_collection(directory, depth=numpy.inf, target_yml_path=None,
                         exclude_regex=None, exclude_hidden=True,
                         describe_files=False):
     """Create a single metadata document to describe a collection of files.
@@ -415,12 +415,13 @@ def describe_collection(directory, depth=1, target_yml_path=None,
 
     Args:
         directory (str): path to collection
-        depth (int, optional): how many subdirectories whose files to (recursively)
-            include. With a depth of 1, only files in the ``directory`` path
-            will be listed in the output metadata document. With a depth of 2,
-            files within folders in the ``directory`` path are included, etc.
-            Can be arbitrarily large to inclue all files in all subdirectories.
-        target_yml_path (str, optional): where to save output yml
+        depth (int): maximum number of subdirectory levels to traverse when
+            walking through ``directory`` to find files included in the
+            collection. A value of 1 limits the walk to files in the top-level
+            ``directory`` only. A value of 2 allows descending into immediate
+            subdirectories, etc. By default, will inclue all files in all
+            subdirectories in the collection.
+        target_yml_path (str, optional): path for output yml
         exclude_regex (str, optional): a regular expression to pattern-match
             any files you do not want included in the output metadata yml.
         exclude_hidden (bool): whether to exclude hidden files (files that
@@ -428,7 +429,9 @@ def describe_collection(directory, depth=1, target_yml_path=None,
         describe_files (bool): whether to ``describe_all`` and create individual
             metadata files for each supported resource in the collection. Using this
             will also add an additional attribute ``collection`` (which refers back
-            to the collection metadata yaml) to any sidecar metadata created 
+            to the collection metadata yaml) to any sidecar metadata created.
+
+    Returns: dictionary of collection metadata
     """
 
     if not target_yml_path:
@@ -677,7 +680,6 @@ def validate_dir(directory, recursive=False):
 
 
 def describe_all(directory, depth=1):
-    #TODO: add depth option or add option to input a list of files into describe_all
     """Describe compatible datasets in the directory.
 
     Take special care to only describe multifile datasets,
@@ -686,9 +688,9 @@ def describe_all(directory, depth=1):
     Args:
         directory (string): path to a directory
         depth (int): maximum number of subdirectory levels to traverse when
-            walking through a directory. A value of 0 limits the walk to the
-            top-level directory only. A value of 1 allows descending into
-            immediate subdirectories, and so on. 
+            walking through a directory. A value of 1 limits the walk to files
+            in the top-level ``directory`` only. A value of 2 allows
+            descending into immediate subdirectories, etc.
     Returns:
         None
 

--- a/src/geometamaker/geometamaker.py
+++ b/src/geometamaker/geometamaker.py
@@ -355,15 +355,9 @@ def describe_collection(directory, depth=5, target_yml_path=None,
 
     Describe all the files within a directory as members of a "collection".
     The resulting metadata resource should include a list of all the files
-    included in the collection, along with their:
-    - name (e.g. lu_table_1)
-    - type (e.g., table)
-    - path (relative to ``directory``)
-    - description (e.g., "table with land codes and descriptions")
-    - scheme (e.g., file)
-    - format (e.g., csv)
+    included in the collection along with a description (or placeholder)
 
-    This is distinct from ``describe_dir``, which
+    This is distinct from ``describe_all``, which
     creates individual metadata files for each supported file in a directory.
 
     Args:
@@ -378,7 +372,7 @@ def describe_collection(directory, depth=5, target_yml_path=None,
             any files you do not want included in the output metadata yml.
         exclude_hidden (bool): whether to exclude hidden files (files that
             start with ".")
-        describe_files (bool): whether to ``describe_dir`` and create individual
+        describe_files (bool): whether to ``describe_all`` and create individual
             metadata files for each supported resource in the collection. Using this
             will also add an additional attribute ``collection`` (which refers back
             to the collection metadata yaml) to any sidecar metadata created 
@@ -528,7 +522,7 @@ def describe_collection(directory, depth=5, target_yml_path=None,
     resource.write()
 
     if describe_files:
-        describe_dir(directory)
+        describe_all(directory)
 
     return resource
 
@@ -706,9 +700,8 @@ def validate_dir(directory, recursive=False):
     return (yaml_files, messages)
 
 
-def describe_dir(directory, recursive=False):
-    #TODO: add depth option or add option to input a list of files into describe_dir
-    #TODO: change ``describe_dir`` to ``describe_all``
+def describe_all(directory, recursive=False):
+    #TODO: add depth option or add option to input a list of files into describe_all
     """Describe all compatible datasets in the directory.
 
     Take special care to only describe multifile datasets,

--- a/src/geometamaker/geometamaker.py
+++ b/src/geometamaker/geometamaker.py
@@ -671,7 +671,7 @@ def validate_dir(directory, recursive=False):
     return (yaml_files, messages)
 
 
-def describe_all(directory, depth=1):
+def describe_all(directory, depth=numpy.inf):
     """Describe compatible datasets in the directory.
 
     Take special care to only describe multifile datasets,

--- a/src/geometamaker/geometamaker.py
+++ b/src/geometamaker/geometamaker.py
@@ -419,7 +419,7 @@ def describe_collection(directory, depth=numpy.inf, exclude_regex=None,
             walking through ``directory`` to find files included in the
             collection. A value of 1 limits the walk to files in the top-level
             ``directory`` only. A value of 2 allows descending into immediate
-            subdirectories, etc. By default, will inclue all files in all
+            subdirectories, etc. By default, will include all files in all
             subdirectories in the collection.
         exclude_regex (str, optional): a regular expression to pattern-match
             any files you do not want included in the output metadata yml.
@@ -439,7 +439,7 @@ def describe_collection(directory, depth=numpy.inf, exclude_regex=None,
 
     # remove excluded files based on regex
     if exclude_regex:
-        file_list = [f for f in file_list if not re.match(exclude_regex, f)]
+        file_list = [f for f in file_list if not re.search(exclude_regex, f)]
     # exclude sidecar ymls
     file_list = [f for f in file_list if not f.endswith(".yml")]
 

--- a/src/geometamaker/models.py
+++ b/src/geometamaker/models.py
@@ -723,7 +723,7 @@ class ArchiveResource(Resource):
     """The compression method used to create the archive."""
 
 
-class ResourcesSchema(Parent):
+class CollectionItemSchema(Parent):
     """Class for keeping track of collections resource info."""
     path: str = ''
     """Path to the resource being described."""
@@ -736,7 +736,7 @@ class ResourcesSchema(Parent):
 class CollectionResource(Resource):
     """Class for metadata for a collection resource."""
 
-    resources: list[ResourcesSchema] = Field(default_factory=list)
+    items: list[CollectionItemSchema] = Field(default_factory=list)
 
     def _dump_for_write(self):
         """Additionally exclude sources and encoding"""

--- a/src/geometamaker/models.py
+++ b/src/geometamaker/models.py
@@ -718,6 +718,30 @@ class ArchiveResource(Resource):
     """The compression method used to create the archive."""
 
 
+class ResourcesSchema(Parent):
+    """Class for keeping track of collections resource info."""
+
+    # name: str = ''
+    # """The name used to uniquely identify the field."""
+    # type: str = ''
+    # """The type of resource being described."""
+    path: str = ''
+    """Path to the resource being described."""
+    # src: str = ''
+    # scheme: str = ''
+    # """File protocol for opening the resource."""
+    # format: str = ''
+    # """File format of the resource."""
+    description: str = ''
+    """A text description of the resource."""
+
+
+class CollectionResource(Resource):
+    """Class for metadata for a collection resource."""
+
+    resources: list[ResourcesSchema] = Field(default_factory=list)
+
+
 class VectorResource(Resource):
     """Class for metadata for a vector resource."""
 

--- a/src/geometamaker/models.py
+++ b/src/geometamaker/models.py
@@ -675,11 +675,6 @@ class Resource(BaseResource):
     or dataset, including encoding and source file references. It serves as a
     base for more specific resource types (e.g., table, raster, vector,
     archive) and is typically initialized by `describe()`.
-
-    Attributes:
-        encoding (str): The text encoding of the resource (e.g., 'utf-8').
-        sources (list[str]): A list of paths to source files that comprise
-            the resource.
     """
 
     encoding: str = ''

--- a/src/geometamaker/models.py
+++ b/src/geometamaker/models.py
@@ -736,7 +736,7 @@ class ArchiveResource(Resource):
 
 
 class CollectionItemSchema(Parent):
-    """Class for keeping track of collections resource info."""
+    """Class for metadata for collection items."""
     path: str = ''
     """Path to the resource being described."""
     description: str = ''
@@ -749,6 +749,7 @@ class CollectionResource(BaseResource):
     """Class for metadata for a collection resource."""
 
     items: list[CollectionItemSchema] = Field(default_factory=list)
+    """Files in collection"""
 
     def model_post_init(self, __context):
         self.metadata_path = self._default_metadata_path()

--- a/src/geometamaker/models.py
+++ b/src/geometamaker/models.py
@@ -749,7 +749,7 @@ class CollectionResource(BaseResource):
     """Class for metadata for a collection resource."""
 
     items: list[CollectionItemSchema] = Field(default_factory=list)
-    """Files in collection"""
+    """Files in collection."""
 
     def model_post_init(self, __context):
         self.metadata_path = self._default_metadata_path()

--- a/src/geometamaker/models.py
+++ b/src/geometamaker/models.py
@@ -720,20 +720,12 @@ class ArchiveResource(Resource):
 
 class ResourcesSchema(Parent):
     """Class for keeping track of collections resource info."""
-
-    # name: str = ''
-    # """The name used to uniquely identify the field."""
-    # type: str = ''
-    # """The type of resource being described."""
     path: str = ''
     """Path to the resource being described."""
-    # src: str = ''
-    # scheme: str = ''
-    # """File protocol for opening the resource."""
-    # format: str = ''
-    # """File format of the resource."""
     description: str = ''
     """A text description of the resource."""
+    metadata: str = ''
+    """Path to metadata document describing resource"""
 
 
 class CollectionResource(Resource):

--- a/tests/test_geometamaker.py
+++ b/tests/test_geometamaker.py
@@ -832,6 +832,7 @@ class GeometamakerTests(unittest.TestCase):
             self.workspace_dir, f'{root_name}.csv.yml')))
 
     def test_describe_collection_with_depth(self):
+        """Test describe_collection with depth and exclude_regex parameters"""
         import geometamaker
 
         collection_path = os.path.join(self.workspace_dir, "collection")
@@ -860,10 +861,12 @@ class GeometamakerTests(unittest.TestCase):
         # subdir and excludes exclude_this.csv
         self.assertEqual(len(metadata.resources), 2)
 
-        geometamaker.describe_collection(collection_path, depth=1,
-                                         describe_files=True)
+        geometamaker.describe_collection(
+            collection_path, depth=1, exclude_regex="exclude_this*",
+            describe_files=True)
         self.assertTrue(os.path.exists(csv_path+".yml"))
         self.assertFalse(os.path.exists(raster_path+".yml"))
+        self.assertFalse(os.path.exists(csv_path_excluded+".yml"))
 
         geometamaker.describe_collection(collection_path, depth=2,
                                          describe_files=True)

--- a/tests/test_geometamaker.py
+++ b/tests/test_geometamaker.py
@@ -861,6 +861,7 @@ class GeometamakerTests(unittest.TestCase):
 
         metadata = geometamaker.describe_collection(
             collection_path, depth=1, exclude_regex="exclude_this*")
+        metadata.write()
         self.assertTrue(os.path.exists(collection_path+"-metadata.yml"))
         # assert that with depth=1, items list only includes csv and
         # subdir and excludes exclude_this.csv

--- a/tests/test_geometamaker.py
+++ b/tests/test_geometamaker.py
@@ -843,9 +843,14 @@ class GeometamakerTests(unittest.TestCase):
         with open(csv_path, 'w') as file:
             file.write('a,b,c')
 
-        # Create csv in main directory
+        # Create csv in main directory (to exclude based on regex)
         csv_path_excluded = os.path.join(collection_path, 'exclude_this.csv')
         with open(csv_path_excluded, 'w') as file:
+            file.write('a,b,c')
+
+        # Create hidden csv in main directory (excluded by default)
+        csv_path_hidden = os.path.join(collection_path, '.table.csv')
+        with open(csv_path_hidden, 'w') as file:
             file.write('a,b,c')
 
         # Create raster in subdirectory
@@ -857,9 +862,9 @@ class GeometamakerTests(unittest.TestCase):
         metadata = geometamaker.describe_collection(
             collection_path, depth=1, exclude_regex="exclude_this*")
         self.assertTrue(os.path.exists(collection_path+"-metadata.yml"))
-        # assert that with depth=1, resources list only includes csv and
+        # assert that with depth=1, items list only includes csv and
         # subdir and excludes exclude_this.csv
-        self.assertEqual(len(metadata.resources), 2)
+        self.assertEqual(len(metadata.items), 2)
 
         geometamaker.describe_collection(
             collection_path, depth=1, exclude_regex="exclude_this*",

--- a/tests/test_geometamaker.py
+++ b/tests/test_geometamaker.py
@@ -842,16 +842,22 @@ class GeometamakerTests(unittest.TestCase):
         with open(csv_path, 'w') as file:
             file.write('a,b,c')
 
+        # Create csv in main directory
+        csv_path_excluded = os.path.join(collection_path, 'exclude_this.csv')
+        with open(csv_path_excluded, 'w') as file:
+            file.write('a,b,c')
+
         # Create raster in subdirectory
         subdir1 = os.path.join(collection_path, "subdir1")
         os.mkdir(subdir1)
         raster_path = os.path.join(subdir1, 'raster.tif')
         create_raster(numpy.int16, raster_path)
 
-        metadata = geometamaker.describe_collection(collection_path, depth=1)
+        metadata = geometamaker.describe_collection(
+            collection_path, depth=1, exclude_regex="exclude_this*")
         self.assertTrue(os.path.exists(collection_path+"-metadata.yml"))
-        # assert that with depth=1, resources list only includes csv and subdir
-        print(metadata.resources)
+        # assert that with depth=1, resources list only includes csv and
+        # subdir and excludes exclude_this.csv
         self.assertEqual(len(metadata.resources), 2)
 
         geometamaker.describe_collection(collection_path, depth=1,

--- a/tests/test_geometamaker.py
+++ b/tests/test_geometamaker.py
@@ -776,12 +776,12 @@ class GeometamakerTests(unittest.TestCase):
             file.write('')
 
         # Only 1 eligible file to describe in the root dir
-        geometamaker.describe_dir(self.workspace_dir)
+        geometamaker.describe_all(self.workspace_dir, depth=1)
         yaml_files, msgs = geometamaker.validate_dir(self.workspace_dir)
         self.assertEqual(len(yaml_files), 1)
 
         # 2 eligible files described with recursive option
-        geometamaker.describe_dir(self.workspace_dir, recursive=True)
+        geometamaker.describe_all(self.workspace_dir)
         yaml_files, msgs = geometamaker.validate_dir(
             self.workspace_dir, recursive=True)
         self.assertEqual(len(yaml_files), 2)
@@ -802,7 +802,7 @@ class GeometamakerTests(unittest.TestCase):
         self.assertEqual(len(yaml_files), 1)
         self.assertEqual(msgs[0], 'is not a readable yaml document')
 
-    def test_describe_dir_with_shapefile(self):
+    def test_describe_all_with_shapefile(self):
         """Test describe directory containing a multi-file dataset."""
         import geometamaker
 
@@ -823,7 +823,7 @@ class GeometamakerTests(unittest.TestCase):
         with patch.object(
                 geometamaker.geometamaker, 'describe',
                 wraps=geometamaker.geometamaker.describe) as mock_describe:
-            geometamaker.describe_dir(self.workspace_dir)
+            geometamaker.describe_all(self.workspace_dir)
 
         self.assertEqual(mock_describe.call_count, describe_count)
         self.assertTrue(os.path.exists(os.path.join(
@@ -1042,7 +1042,7 @@ class CLITests(unittest.TestCase):
         create_raster(numpy.int16, datasource_path)
 
         runner = CliRunner()
-        result = runner.invoke(cli.cli, ['describe', '-r', self.workspace_dir])
+        result = runner.invoke(cli.cli, ['describe', self.workspace_dir])
         self.assertEqual(result.exit_code, 0)
         self.assertEqual(result.output, '')
         self.assertTrue(os.path.exists(f'{datasource_path}.yml'))
@@ -1055,7 +1055,7 @@ class CLITests(unittest.TestCase):
         create_raster(numpy.int16, datasource_path)
 
         runner = CliRunner()
-        result = runner.invoke(cli.cli, ['describe', '-r', datasource_path])
+        result = runner.invoke(cli.cli, ['describe', datasource_path])
         self.assertEqual(result.exit_code, 0)
         self.assertEqual(result.output, '')
         self.assertTrue(os.path.exists(f'{datasource_path}.yml'))
@@ -1147,7 +1147,7 @@ class CLITests(unittest.TestCase):
         with open(yml2, 'w') as file:
             file.write('')
 
-        geometamaker.describe_dir(self.workspace_dir, recursive=True)
+        geometamaker.describe_all(self.workspace_dir)
 
         runner = CliRunner()
         result = runner.invoke(cli.cli, ['validate', '-r', self.workspace_dir])

--- a/tests/test_geometamaker.py
+++ b/tests/test_geometamaker.py
@@ -831,6 +831,38 @@ class GeometamakerTests(unittest.TestCase):
         self.assertTrue(os.path.exists(os.path.join(
             self.workspace_dir, f'{root_name}.csv.yml')))
 
+    def test_describe_collection_with_depth(self):
+        import geometamaker
+
+        collection_path = os.path.join(self.workspace_dir, "collection")
+        os.mkdir(collection_path)
+
+        # Create csv in main directory
+        csv_path = os.path.join(collection_path, 'table.csv')
+        with open(csv_path, 'w') as file:
+            file.write('a,b,c')
+
+        # Create raster in subdirectory
+        subdir1 = os.path.join(collection_path, "subdir1")
+        os.mkdir(subdir1)
+        raster_path = os.path.join(subdir1, 'raster.tif')
+        create_raster(numpy.int16, raster_path)
+
+        metadata = geometamaker.describe_collection(collection_path, depth=1)
+        self.assertTrue(os.path.exists(collection_path+"-metadata.yml"))
+        # assert that with depth=1, resources list only includes csv and subdir
+        print(metadata.resources)
+        self.assertEqual(len(metadata.resources), 2)
+
+        geometamaker.describe_collection(collection_path, depth=1,
+                                         describe_files=True)
+        self.assertTrue(os.path.exists(csv_path+".yml"))
+        self.assertFalse(os.path.exists(raster_path+".yml"))
+
+        geometamaker.describe_collection(collection_path, depth=2,
+                                         describe_files=True)
+        self.assertTrue(os.path.exists(raster_path+".yml"))
+
 
 class ValidationTests(unittest.TestCase):
     """Tests for geometamaker type validation."""


### PR DESCRIPTION
Users can now create metadata for collections, i.e., folders. Collection-level metadata includes a list of the files contained within the directory, along with their `description`s and `metadata` (or placeholders if none). Users can specify `depth` to determine how many subdirectories to traverse when identifying files in the collection. It is also possible to provide a regular expression to exclude certain files from collection metadata. Hidden files are excluded by default.

Note that Collections are described slightly differently than other resources:
- collection metadata are located in a sibling directory and are tagged with `-metadata` (i.e., the metadata for /path/to/collection will be /path/to/collection-metadata.yml
- users cannot call `describe` on collections

`describe_dir` has been renamed to `describe_all` to help differentiate it from `describe_collection`, and `recursive` has been removed in favor of `depth`, to allow for more fine-grained control.

Fixes: #66