### PR TITLE
Bugfix/132 gdal compatibility

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,7 +23,13 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
+        gdal: ["3.11", "3.12"]
         os: [ubuntu-latest, windows-latest, macos-latest]
+        exclude:
+          - os: windows-latest
+            gdal: "3.11" 
+          - os: macos-latest
+            gdal: "3.11"
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,13 +23,13 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
-        gdal: ["3.11", "3.12"]
+        gdal-version: ["3.11", "3.12"]
         os: [ubuntu-latest, windows-latest, macos-latest]
         exclude:
           - os: windows-latest
-            gdal: "3.11" 
+            gdal-version: "3.11" 
           - os: macos-latest
-            gdal: "3.11"
+            gdal-version: "3.11"
 
     steps:
       - uses: actions/checkout@v3
@@ -48,6 +48,7 @@ jobs:
                 - conda-forge
           create-args: >-
               python=${{ matrix.python-version }}
+              gdal=${{ matrix.gdal-version }}
               setuptools
               python-build
               pytest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ defaults:
 jobs:
   Test:
     runs-on: ${{ matrix.os }}
-    name: Test (py${{ matrix.python-version }}, GDAL ${{ matrix.gdal }}, ${{ matrix.os }})
+    name: Test (py${{ matrix.python-version }}, GDAL ${{ matrix.gdal-version }}, ${{ matrix.os }})
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,6 +19,7 @@ defaults:
 jobs:
   Test:
     runs-on: ${{ matrix.os }}
+    name: Test (py${{ matrix.python-version }}, GDAL ${{ matrix.gdal }}, ${{ matrix.os }})
     strategy:
       fail-fast: false
       matrix:

--- a/src/geometamaker/utils.py
+++ b/src/geometamaker/utils.py
@@ -58,9 +58,9 @@ _GFT_INT_TO_STR = {
     gdal.GFT_Integer: 'Integer',
     gdal.GFT_Real: 'Real',
     gdal.GFT_String: 'String',
-    gdal.GFT_Boolean: 'Boolean',
-    gdal.GFT_DateTime: 'DateTime',
-    gdal.GFT_WKBGeometry: 'WKBGeometry',
+    3: 'Boolean',      # gdal.GFT_Boolean (not available until GDAL 3.12)
+    4: 'DateTime',     # gdal.GFT_DateTime
+    5: 'WKBGeometry',  # gdal.GFT_WKBGeometry
 }
 
 _GRTT_INT_TO_STR = {

--- a/tests/test_geometamaker.py
+++ b/tests/test_geometamaker.py
@@ -400,13 +400,20 @@ class GeometamakerTests(unittest.TestCase):
         rat = gdal.RasterAttributeTable()
         value_name = 'Value'
         count_name = 'Count'
+        bool_name = 'Bool'
         rat.CreateColumn(value_name, gdal.GFT_Integer, gdal.GFU_MinMax)
         rat.CreateColumn(count_name, gdal.GFT_Integer, gdal.GFU_PixelCount)
+        if geometamaker.geometamaker.GDAL_VERSION < (3, 12, 0):
+            rat.CreateColumn(bool_name, gdal.GFT_Integer, gdal.GFU_Generic)
+        else:
+            rat.CreateColumn(bool_name, gdal.GFT_Boolean, gdal.GFU_Generic)
+
         array = band.ReadAsArray()
         values, counts = numpy.unique(array, return_counts=True)
         for i in range(len(values)):
             rat.SetValueAsInt(i, 0, int(values[i]))
             rat.SetValueAsInt(i, 1, int(counts[i]))
+            rat.SetValueAsBoolean(i, 2, True)
         band.SetDefaultRAT(rat)
         band = raster = None
 
@@ -420,6 +427,13 @@ class GeometamakerTests(unittest.TestCase):
         self.assertEqual(table.columns[1].name, count_name)
         self.assertEqual(table.columns[1].type, 'Integer')
         self.assertEqual(table.columns[1].usage, 'PixelCount')
+        self.assertEqual(table.columns[2].name, bool_name)
+        self.assertEqual(table.columns[2].usage, 'Generic')
+
+        if geometamaker.geometamaker.GDAL_VERSION < (3, 12, 0):
+            self.assertEqual(table.columns[2].type, 'Integer')
+        else:
+            self.assertEqual(table.columns[2].type, 'Boolean')
 
     def test_describe_raster_with_dbf_rat(self):
         """Test raster attribute table can be constructed from vat.dbf."""

--- a/tests/test_geometamaker.py
+++ b/tests/test_geometamaker.py
@@ -413,7 +413,12 @@ class GeometamakerTests(unittest.TestCase):
         for i in range(len(values)):
             rat.SetValueAsInt(i, 0, int(values[i]))
             rat.SetValueAsInt(i, 1, int(counts[i]))
-            rat.SetValueAsBoolean(i, 2, True)
+            # Even though this 3rd column is supposed to be the Boolean column
+            # Set as an Int because SetValueAsBoolean is only available after
+            # GDAL 3.12. We still created the column as a GFT_Boolean, so
+            # the real test is that it parses back as Boolean, even if the value
+            # is written as an int.
+            rat.SetValueAsInt(i, 2, 1)
         band.SetDefaultRAT(rat)
         band = raster = None
 


### PR DESCRIPTION
Guard against accessing attributes that are not available before GDAL 3.12. 

When loading a RAT, we ask GDAL to get the type of each column and then read values using the method appropriate for that type. GDAL will only return types that it knows how to read. if it cannot determine the type it returns 'Integer'. So the only real bug here was accessing the constants for certain types in our utils.py module.