### PR TITLE
updated HISTORY for release 0.3.1

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,6 +1,13 @@
 Release History
 ===============
 
+0.3.1 (2026-04-13)
+------------------
+* Version 0.3.0 was unintentionally incompatible with GDAL < 3.12.0. 
+  This bugfix restores compatibility and adds tests against GDAL 3.11
+  and GDAL 3.12. https://github.com/natcap/geometamaker/issues/132
+
+
 0.3.0 (2026-04-10)
 ------------------
 * Fixed a bug where extra attributes returned from frictionless


### PR DESCRIPTION
Here's a suite of invest tests that installed `geometamaker` from `main`. This should give us confidence that `geometamaker` is compatible with all the environments in that test matrix.
https://github.com/davemfish/invest/actions/runs/24372621641
