### PR TITLE
Bugfix for reading DBF raster attribute tables with GDAL < 3.11.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,11 +26,6 @@ jobs:
         python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
         gdal-version: ["3.10", "3.11", "3.12", "3.13"]
         os: [ubuntu-latest, windows-latest, macos-latest]
-        exclude:
-          - os: windows-latest
-            gdal-version: ["3.10", "3.11", "3.12"]
-          - os: macos-latest
-            gdal-version: ["3.10", "3.11", "3.12"]
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,13 +24,13 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
-        gdal-version: ["3.11", "3.12"]
+        gdal-version: ["3.10", "3.11", "3.12", "3.13"]
         os: [ubuntu-latest, windows-latest, macos-latest]
         exclude:
           - os: windows-latest
-            gdal-version: "3.11" 
+            gdal-version: ["3.10", "3.11", "3.12"]
           - os: macos-latest
-            gdal-version: "3.11"
+            gdal-version: ["3.10", "3.11", "3.12"]
 
     steps:
       - uses: actions/checkout@v3

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,6 +1,12 @@
 Release History
 ===============
 
+Unreleased Changes
+------------------
+* Fixed a bug where a raster attribute table stored in a DBF file
+  would be ignored during ``describe`` if using GDAL < 3.11.0.
+  https://github.com/natcap/geometamaker/issues/140
+
 0.3.2 (2026-05-19)
 ------------------
 * ``pandas`` replaces ``frictionless`` for reading tabular data. Supported

--- a/src/geometamaker/geometamaker.py
+++ b/src/geometamaker/geometamaker.py
@@ -405,7 +405,7 @@ def describe_raster(source_dataset_path, scheme, **kwargs):
         elif GDAL_VERSION < (3, 11, 0):
             # GetDefaultRAT did not support DBF prior to 3.11.0
             dbf_rat = f'{source_dataset_path}.vat.dbf'
-            if dbf_rat in info['file_list']:
+            if os.path.exists(dbf_rat):
                 rat = models.RasterAttributeTable.from_gdal_dbf(dbf_rat)
 
         band_gdal_metadata = band.GetMetadata()

--- a/tests/test_geometamaker.py
+++ b/tests/test_geometamaker.py
@@ -461,15 +461,13 @@ class GeometamakerTests(unittest.TestCase):
 
     def test_describe_raster_with_dbf_rat(self):
         """Test raster attribute table can be constructed from vat.dbf."""
-        from geometamaker import models
+        import geometamaker
 
         datasource_path = os.path.join(
-            os.path.dirname(__file__), 'data/testrat.tif.vat.dbf')
+            os.path.dirname(__file__), 'data/testrat.tif')
 
-        # Calling this method directly instead of `describe`
-        # because depending on GDAL version, this method may not be used
-        # and the resulting table would have minor differences.
-        table = models.RasterAttributeTable.from_gdal_dbf(datasource_path)
+        resource = geometamaker.describe(datasource_path)
+        table = resource.get_rat(1)
 
         self.assertEqual(len(table.rows), 2)
         self.assertEqual(len(table.columns), 9)
@@ -477,14 +475,30 @@ class GeometamakerTests(unittest.TestCase):
             [col.name for col in table.columns],
             ["VALUE", "COUNT", "CLASS", "Red", "Green", "Blue", "OtherInt",
              "OtherReal", "OtherStr"])
+        
+        # GDAL does not read a DBF RAT by default, so there are differences
+        # In how we constructed the list of types vs how later versions of
+        # GDAL will do it.
+        expected_types = [
+            "Integer", "Integer", "String", "Integer", "Integer", "Integer",
+            "Integer", "Real", "String"]
+        expected_usages = [
+            'MinMax', 'PixelCount', 'Name', 'Red', 'Green', 'Blue',
+            'Generic', 'Generic', 'Generic']
+        if geometamaker.geometamaker.GDAL_VERSION < (3, 11, 0):
+            expected_types = [
+                "Integer", "Integer", "String", "Real", "Real", "Real",
+                "Integer", "Real", "String"]
+            expected_usages = [
+                "MinMax", "PixelCount", "Generic", "Generic", "Generic", "Generic",
+                "Generic", "Generic", "Generic"]
+
         self.assertEqual(
             [col.type for col in table.columns],
-            ["Integer", "Integer", "String", "Real", "Real", "Real", "Integer",
-             "Real", "String"])
+            expected_types)
         self.assertEqual(
             [col.usage for col in table.columns],
-            ["MinMax", "PixelCount", "Generic", "Generic", "Generic", "Generic", "Generic",
-             "Generic", "Generic"])
+            expected_usages)
 
     def test_describe_vector_with_gdal_metadata(self):
         """Test vector metadata will be included if they already exist."""


### PR DESCRIPTION
A fix for reading DBF raster attribute tables with GDAL < 3.11.

Fixes #140 
